### PR TITLE
fix list index out of range bug when using byte_count with overlap = Y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2021-08-12
+
+- Bug fix for error while using byte_count with overlap = Y.
+
 ## [0.7.0] - 2021-08-11
 - Adding support for floating point extension coverpoints
 - Bug fixes for instruction decoder and improved pretty printing.

--- a/riscv_isac/__init__.py
+++ b/riscv_isac/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -154,9 +154,11 @@ def byte_count(xlen, variables=['rs1_val','rs2_val','imm_val'], overlap = "N"):
     hex_str = ""
     i=0
     cvpt = ""
-
-    while(i<=256):
-    	hex_str = "{:02x}".format(i) + hex_str
+    max = 255
+    if overlap == "Y":
+    	max += xlen/16
+    while(i<=max):
+    	hex_str = "{:02x}".format(i % 256) + hex_str
     	if((len(hex_str)/2)%(xlen/8) == 0):
     		rs2.append('0x'+hex_str)
     		hex_str = ""

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -185,7 +185,7 @@ def byte_count(xlen, variables=['rs1_val','rs2_val','imm_val'], overlap = "N"):
     			else:
     				coverpoints.append(cvpt + ' #nosat')
     			cvpt = ""
-    	elif variables[1] == "rcon":
+    	elif variables[1] == "imm_val":
     		for i in range(len(rs2)):
     			coverpoints.append(variables[0] +' == '+ rs2[i] +' and '+ variables[1] +' == 0xA' + ' #nosat')
     return [(coverpoint,"Byte Count") for coverpoint in coverpoints]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.7.1
 commit = True
 tag = True
 
@@ -18,3 +18,4 @@ universal = 1
 exclude = docs
 
 [aliases]
+

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_isac',
-    version='0.7.0',
+    version='0.7.1',
     description="RISC-V ISAC",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
fix support  for aes64ks1i using byte_count with variables=['rs1_val', 'imm_val']
Using byte_count with variables=['rs1_val','rs2_val','imm_val'] and overlap = "Y" will trigger "list index out of range" exception.