### PR TITLE
Support for coverage of Privilged Architecture

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,8 +37,7 @@ version = str(get_version())
 release = version
 
 def setup(app):
-    app.add_stylesheet("custom.css")
-    app.add_css_file("_static/custom.css")
+    app.add_css_file("custom.css")
 
 # -- General configuration ---------------------------------------------------
 
@@ -81,7 +80,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -92,6 +91,8 @@ pygments_style = 'sphinx'
 
 autodoc_member_order = 'bysource'
 
+#Mention the reference files
+bibtex_bibfiles = ['refs.bib']
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -194,7 +194,10 @@ Help text for each command can be accessed by executing ``riscv_isac <command> -
           -e, --elf PATH                  ELF file
           -t, --trace-file PATH           Instruction trace file to be analyzed
                                           [required]
-        
+
+          -h, --header-file PATH          YAML macro file to include
+          -cm, --cgf-macro CGF MACROS     CGF macros to consider for this run.
+
           -c, --cgf-file PATH             Coverage Group File(s). Multiple allowed.
                                           [required]
         

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -82,7 +82,8 @@ class instructionObject():
         rm = None,
         reg_commit = None,
         csr_commit = None,
-        mnemonic = None
+        mnemonic = None,
+        mode = None
     ):
 
         '''
@@ -121,7 +122,7 @@ class instructionObject():
         self.rs2_nregs = 1
         self.rs3_nregs = 1
         self.rd_nregs = 1
-
+        self.mode = mode
 
     def is_sig_update(self):
         return self.instr_name in instrs_sig_update
@@ -140,6 +141,7 @@ class instructionObject():
         '''
         instr_vars['xlen'] = xlen
         instr_vars['flen'] = flen
+        instr_vars['mode'] = self.mode
 
         instr_vars['iflen'] = flen
         if self.instr_name.endswith(".s") or 'fmv.x.w' in self.instr_name:

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -154,6 +154,7 @@ class instructionObject():
         instr_vars['xlen'] = xlen
         instr_vars['flen'] = flen
         instr_vars['mode'] = self.mode
+        instr_vars['mnemonic'] = self.instr_name
 
         instr_vars['iflen'] = flen
         if self.instr_name.endswith(".s") or 'fmv.x.w' in self.instr_name:

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -485,13 +485,18 @@ class instructionObject():
             if trap_dict["mode_change"].split()[2] == "M":
                 instr_vars['mcause']      = trap_dict['exc_num']
                 instr_vars['mtval']       = trap_dict['tval']
-                instr_vars['scause']      = '0'
-                instr_vars['stval']       = '0'
+                #only update on the initialization
+                if "scause" not in instr_vars:
+                    instr_vars['scause']      = '0'
+                    instr_vars['stval']       = '0'
+
             elif trap_dict["mode_change"].split()[2] == "S":
                 instr_vars['scause']      = trap_dict['exc_num']
                 instr_vars['stval']       = trap_dict['tval']
-                instr_vars['mcause']      = '0'
-                instr_vars['mtval']       = '0'
+                #only update on the initialization
+                if "mcause" not in instr_vars:
+                    instr_vars['mcause']      = '0'
+                    instr_vars['mtval']       = '0'
         else:
                 instr_vars['mcause']      = '0'
                 instr_vars['mtval']       = '0'

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -231,7 +231,7 @@ class instructionObject():
 
             if self.csr_commit is not None:
                 for commit in self.csr_commit:
-                    if commit[0] == "CSR" and commit[2] != '->':
+                    if commit[0] == "CSR":
                         csr_reg = commit[1]
                         if csr_reg not in regs_to_track_immutable:
                             regs_to_track_immutable.append(csr_reg)
@@ -263,7 +263,7 @@ class instructionObject():
 
         if self.csr_commit is not None:
             for commit in self.csr_commit:
-                if commit[0] == "CSR" and commit[2] != '->':
+                if commit[0] == "CSR":
                     csr_reg = commit[1]
 
                     if csr_regfile[csr_reg] != str(commit[3][2:]):

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -366,20 +366,16 @@ class instructionObject():
             instr_vars['len_dptw'] = size
             remain = max_len
             length = max_len - size - 1
-
-            if (max_len >= size):
-                for i in range(size):
-                    instr_vars[f'dptw{max_len-1}a'] = int(self.vm_addr_dict['dptw_list'][i][0], 16)
-                    instr_vars[f'dptw{max_len-1}cont'] = int(self.vm_addr_dict['dptw_list'][i][1], 16)
-                    max_len = max_len -1
-                for i in range(length, -1, -1):
-                    instr_vars[f'dptw{i}cont'] = None
-                    instr_vars[f'dptw{i}a'] = None
-                for i in range(remain, 5):
-                    instr_vars[f'dptw{i}cont'] = None
-                    instr_vars[f'dptw{i}a'] = None
-            else:
-                raise Exception("Implemented Virtual Memory in the Test and the one given in the coverpoints is not same.")
+            for i in range(size):
+                instr_vars[f'dptw{max_len-1}a'] = int(self.vm_addr_dict['dptw_list'][i][0], 16)
+                instr_vars[f'dptw{max_len-1}cont'] = int(self.vm_addr_dict['dptw_list'][i][1], 16)
+                max_len = max_len -1
+            for i in range(length, -1, -1):
+                instr_vars[f'dptw{i}cont'] = None
+                instr_vars[f'dptw{i}a'] = None
+            for i in range(remain, 5):
+                instr_vars[f'dptw{i}cont'] = None
+                instr_vars[f'dptw{i}a'] = None
         else:
             instr_vars['depa'] = None
             instr_vars['ieva'] = None
@@ -426,19 +422,16 @@ class instructionObject():
                 iptw_dict['len_iptw'] = size
                 remain = max_len
                 length = max_len - size - 1
-                if (max_len >= size):
-                    for i in range(size):
-                        iptw_dict[f'iptw{max_len-1}a'] = int(self.vm_addr_dict['iptw_list'][i][0], 16)
-                        iptw_dict[f'iptw{max_len-1}cont'] = int(self.vm_addr_dict['iptw_list'][i][1], 16)
-                        max_len = max_len -1
-                    for i in range(length, -1, -1):
-                        iptw_dict[f'iptw{i}a'] = None
-                        iptw_dict[f'iptw{i}cont'] = None
-                    for i in range(remain, 5):
-                        iptw_dict[f'iptw{i}a'] = None
-                        iptw_dict[f'iptw{i}cont'] = None
-                else:
-                    raise Exception("Implemented Virtual Memory in the Test and the one given in the coverpoints is not same.")
+                for i in range(size):
+                    iptw_dict[f'iptw{max_len-1}a'] = int(self.vm_addr_dict['iptw_list'][i][0], 16)
+                    iptw_dict[f'iptw{max_len-1}cont'] = int(self.vm_addr_dict['iptw_list'][i][1], 16)
+                    max_len = max_len -1
+                for i in range(length, -1, -1):
+                    iptw_dict[f'iptw{i}a'] = None
+                    iptw_dict[f'iptw{i}cont'] = None
+                for i in range(remain, 5):
+                    iptw_dict[f'iptw{i}a'] = None
+                    iptw_dict[f'iptw{i}cont'] = None
             else:
                 for i in range(0, 5):
                     iptw_dict[f'iptw{i}a'] = None

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -132,7 +132,7 @@ class instructionObject():
         return self.instr_name in instrs_sig_update
 
 
-    def evaluate_instr_vars(self, xlen, flen, arch_state, csr_regfile, instr_vars, matches_for_options):
+    def evaluate_instr_vars(self, xlen, flen, arch_state, csr_regfile, instr_vars):
         '''
         This function populates the provided instr_vars dictionary
         with the necessary fields to evaluate the coverpoints.
@@ -143,8 +143,6 @@ class instructionObject():
         :param csr_regfile: Architectural state of CSR register files
         :param instr_vars: Dictionary to be populated by the evaluated instruction variables
         '''
-        self.matches_for_options = matches_for_options
-        self.ptw_update(instr_vars)
 
         instr_vars['xlen'] = xlen
         instr_vars['flen'] = flen
@@ -281,14 +279,13 @@ class instructionObject():
         return changed_regs
 
 
-    def update_arch_state(self, arch_state, csr_regfile, iptw_dict, mem_vals):
+    def update_arch_state(self, arch_state, csr_regfile, mem_vals):
         '''
         This function updates the arch state and csr regfiles
         with the effect of this instruction.
 
         :param csr_regfile: Architectural state of CSR register files
         :param instr_vars: Dictionary to be populated by the evaluated instruction variables
-        :param iptw_dict: Dictionary holding the values of PTW addresses for current instruction
         :param mem_vals: Dictionary to be populated for the memory values
         '''
         arch_state.pc = self.instr_addr
@@ -306,7 +303,6 @@ class instructionObject():
                 if (commit[0] == "CSR") and commit[2] != '->':
                     csr_regfile[commit[1]] = str(commit[3][2:])
 
-        self.iptw_update(iptw_dict)
 
         mem_val = self.mem_val
         if mem_val is not None:
@@ -342,65 +338,116 @@ class instructionObject():
                             in case when the virtual memory is mentioned under the config
                             label.
         '''
-        for match in self.matches_for_options:
-            if match[0] == 'VM' and match[1] in ['SV32', 'SV39', 'SV48', 'SV57']:
-                instr_vars['depa'] = self.vm_addr_dict['depa']
-                instr_vars['ieva'] = self.vm_addr_dict['ieva']
-                instr_vars['iepa'] = self.vm_addr_dict['iepa']
-                instr_vars['ieva_align'] = self.vm_addr_dict['ieva_align']
-                instr_vars['iepa_align'] = self.vm_addr_dict['iepa_align']
-                instr_vars['depa_align'] = self.vm_addr_dict['depa_align']
-                format_max_len_mapping = {'SV32': 2, 'SV39': 3, 'SV48': 4, 'SV57': 5}
-                max_len = format_max_len_mapping.get(match[1],0)
-                size = len(self.vm_addr_dict['dptw_list'])
-                instr_vars['len_dptw'] = size
-                remain = max_len
-                length = max_len - size - 1
+        match = ['VM']
+        if instr_vars['xlen'] == 32:
+            if ((instr_vars['satp']) >> 31) == 1:
+                match.append('SV32')
+            else:
+                match.append(0)
+        elif instr_vars['xlen'] == 64:
+            if ((instr_vars['satp']) >> 60) == 8:
+                match.append('SV39')
+            elif ((instr_vars['satp']) >> 60) == 9:
+                match.append('SV48')
+            elif ((instr_vars['satp']) >> 60) == 10:
+                match.append('SV57')
+            else:
+                match.append(0)
+        if match[0] == 'VM' and match[1] in ['SV32', 'SV39', 'SV48', 'SV57']:
+            instr_vars['depa'] = self.vm_addr_dict['depa']
+            instr_vars['ieva'] = self.vm_addr_dict['ieva']
+            instr_vars['iepa'] = self.vm_addr_dict['iepa']
+            instr_vars['ieva_align'] = self.vm_addr_dict['ieva_align']
+            instr_vars['iepa_align'] = self.vm_addr_dict['iepa_align']
+            instr_vars['depa_align'] = self.vm_addr_dict['depa_align']
+            format_max_len_mapping = {'SV32': 2, 'SV39': 3, 'SV48': 4, 'SV57': 5}
+            max_len = format_max_len_mapping.get(match[1],0)
+            size = len(self.vm_addr_dict['dptw_list'])
+            instr_vars['len_dptw'] = size
+            remain = max_len
+            length = max_len - size - 1
 
-                if (max_len >= size):
-                    for i in range(size):
-                        instr_vars[f'dptw{max_len-1}a'] = int(self.vm_addr_dict['dptw_list'][i][0], 16)
-                        max_len = max_len -1
-                    for i in range(length, -1, -1):
-                        instr_vars[f'dptw{i}a'] = None
-                    for i in range(remain, 5):
-                        instr_vars[f'dptw{i}a'] = None
-                else:
-                    raise Exception("Implemented Virtual Memory in the Test and the one given in the coverpoints is not same.")
-
+            if (max_len >= size):
+                for i in range(size):
+                    instr_vars[f'dptw{max_len-1}a'] = int(self.vm_addr_dict['dptw_list'][i][0], 16)
+                    instr_vars[f'dptw{max_len-1}cont'] = int(self.vm_addr_dict['dptw_list'][i][1], 16)
+                    max_len = max_len -1
+                for i in range(length, -1, -1):
+                    instr_vars[f'dptw{i}cont'] = None
+                    instr_vars[f'dptw{i}a'] = None
+                for i in range(remain, 5):
+                    instr_vars[f'dptw{i}cont'] = None
+                    instr_vars[f'dptw{i}a'] = None
+            else:
+                raise Exception("Implemented Virtual Memory in the Test and the one given in the coverpoints is not same.")
+        else:
+            instr_vars['depa'] = None
+            instr_vars['ieva'] = None
+            instr_vars['iepa'] = None
+            instr_vars['ieva_align'] = None
+            instr_vars['iepa_align'] = None
+            instr_vars['depa_align'] = None
+            instr_vars['len_dptw']   = None
+            for i in range(0, 5):
+                instr_vars[f'dptw{i}a'] = None
+                instr_vars[f'dptw{i}cont'] = None
         return None
 
-    def iptw_update(self,iptw_dict):
+    def iptw_update(self, instr_vars, iptw_dict):
         '''
         This function page table walk addresses 
         for the data.
-        
+
+        :param instr_vars: Dictionary holding the values of current instruction state.
+
         :param iptw_dict : dictionary that contains the current instruction's
                             page table walk addresses.
         '''
+        match = ['VM']
+        if instr_vars['xlen'] == 32:
+            if ((instr_vars['satp']) >> 31) == 1:
+                match.append('SV32')
+            else:
+                match.append(0)
+        elif instr_vars['xlen'] == 64:
+            if ((instr_vars['satp']) >> 60) == 8:
+                match.append('SV39')
+            elif ((instr_vars['satp']) >> 60) == 9:
+                match.append('SV48')
+            elif ((instr_vars['satp']) >> 60) == 10:
+                match.append('SV57')
+            else:
+                match.append(0)
         if (len(self.vm_addr_dict['iptw_list'])) != 0:
-            for match in self.matches_for_options:
-                if match[0] == 'VM' and match[1] in ['SV32', 'SV39', 'SV48', 'SV57']:
-                    format_max_len_mapping = {'SV32': 2, 'SV39': 3, 'SV48': 4, 'SV57': 5}
-                    max_len = format_max_len_mapping.get(match[1],0)
-                    size = len(self.vm_addr_dict['iptw_list'])
-                    iptw_dict['len_iptw'] = size
-                    remain = max_len
-                    length = max_len - size - 1
-                    if (max_len >= size):
-                        for i in range(size):
-                            iptw_dict[f'iptw{max_len-1}a'] = int(self.vm_addr_dict['iptw_list'][i][0], 16)
-                            max_len = max_len -1
-                        for i in range(length, -1, -1):
-                            iptw_dict[f'iptw{i}a'] = None
-                        for i in range(remain, 5):
-                            iptw_dict[f'iptw{i}a'] = None
-                    else:
-                        raise Exception("Implemented Virtual Memory in the Test and the one given in the coverpoints is not same.")
-        
+            if match[0] == 'VM' and match[1] in ['SV32', 'SV39', 'SV48', 'SV57']:
+                format_max_len_mapping = {'SV32': 2, 'SV39': 3, 'SV48': 4, 'SV57': 5}
+                max_len = format_max_len_mapping.get(match[1],0)
+                size = len(self.vm_addr_dict['iptw_list'])
+                iptw_dict['len_iptw'] = size
+                remain = max_len
+                length = max_len - size - 1
+                if (max_len >= size):
+                    for i in range(size):
+                        iptw_dict[f'iptw{max_len-1}a'] = int(self.vm_addr_dict['iptw_list'][i][0], 16)
+                        iptw_dict[f'iptw{max_len-1}cont'] = int(self.vm_addr_dict['iptw_list'][i][1], 16)
+                        max_len = max_len -1
+                    for i in range(length, -1, -1):
+                        iptw_dict[f'iptw{i}a'] = None
+                        iptw_dict[f'iptw{i}cont'] = None
+                    for i in range(remain, 5):
+                        iptw_dict[f'iptw{i}a'] = None
+                        iptw_dict[f'iptw{i}cont'] = None
+                else:
+                    raise Exception("Implemented Virtual Memory in the Test and the one given in the coverpoints is not same.")
+            else:
+                for i in range(0, 5):
+                    iptw_dict[f'iptw{i}a'] = None
+                    iptw_dict[f'iptw{i}cont'] = None
+                iptw_dict['len_iptw'] = 0
         elif self.mode == 'M':
             for i in range(0, 5):
                 iptw_dict[f'iptw{i}a'] = None
+                iptw_dict[f'iptw{i}cont'] = None
             iptw_dict['len_iptw'] = 0
 
         return None

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -33,11 +33,11 @@ unsgn_rs2 = ['bgeu', 'bltu', 'sltiu', 'sltu', 'sll', 'srl', 'sra','mulhu',\
         'clmulh','clmulr','andn','orn','xnor','pack','packh','packu','packuw','packw',\
         'xperm.n','xperm.b', 'aes32esmi', 'aes32esi', 'aes32dsmi', 'aes32dsi',\
         'sha512sum1r','sha512sum0r','sha512sig1l','sha512sig1h','sha512sig0l','sha512sig0h','fsw',\
-        'bclr','bext','binv','bset','minu','maxu','add.uw','sh1add.uw','sh2add.uw','sh3add.uw','sc.w','lr.w']
+        'bclr','bext','binv','bset','minu','maxu','add.uw','sh1add.uw','sh2add.uw','sh3add.uw', 'sc.w']
 f_instrs_pref = ['fadd', 'fclass', 'fcvt', 'fdiv', 'feq', 'fld', 'fle', 'flt', 'flw', 'fmadd',\
         'fmax', 'fmin', 'fmsub', 'fmul', 'fmv', 'fnmadd', 'fnmsub', 'fsd', 'fsgnj', 'fsqrt',\
         'fsub', 'fsw']
-unsgn_rd = unsgn_rs1
+unsgn_rd = ['lr.w','sc.w']
 
 
 instr_var_evaluator_funcs = {} # dictionary for holding registered evaluator funcs
@@ -573,6 +573,10 @@ class instructionObject():
     @evaluator_func("rd_val", lambda **params: params['instr_name'] in unsgn_rd and params['rd'] is not None)
     def evaluate_rd_val_unsgn(self, instr_vars, arch_state):
         return self.evaluate_reg_val_unsgn(self.rd[0], instr_vars['xlen'], arch_state)
+
+    @evaluator_func("rd_val", lambda **params: not params['instr_name'] in unsgn_rd and params['rd'] is not None  and params['rd'][1] == 'x')
+    def evaluate_rd_val_sgn(self, instr_vars, arch_state):
+        return self.evaluate_reg_val_sgn(self.rd[0], instr_vars['xlen'], arch_state)
 
 
     '''

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -231,7 +231,7 @@ class instructionObject():
 
             if self.csr_commit is not None:
                 for commit in self.csr_commit:
-                    if commit[0] == "CSR":
+                    if commit[0] == "CSR" and commit[2] != '->':
                         csr_reg = commit[1]
                         if csr_reg not in regs_to_track_immutable:
                             regs_to_track_immutable.append(csr_reg)
@@ -263,10 +263,10 @@ class instructionObject():
 
         if self.csr_commit is not None:
             for commit in self.csr_commit:
-                if commit[0] == "CSR":
+                if commit[0] == "CSR" and commit[2] != '->':
                     csr_reg = commit[1]
 
-                    if csr_regfile[csr_reg] != str(commit[2][2:]):
+                    if csr_regfile[csr_reg] != str(commit[3][2:]):
                         changed_regs.append(csr_reg)
 
         return changed_regs
@@ -291,9 +291,9 @@ class instructionObject():
 
         csr_commit = self.csr_commit
         if csr_commit is not None:
-            for commits in csr_commit:
-                if (commits[0] == "CSR"):
-                    csr_regfile[commits[1]] = str(commits[2][2:])
+            for commit in csr_commit:
+                if (commit[0] == "CSR") and commit[2] != '->':
+                    csr_regfile[commit[1]] = str(commit[3][2:])
 
 
     def evaluate_instr_var(self, instr_var_name, *args):

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -309,7 +309,6 @@ class instructionObject():
                 if (commit[0] == "CSR") and commit[2] != '->':
                     csr_regfile[commit[1]] = str(commit[3][2:])
 
-
         mem_val = self.mem_val
         if mem_val is not None:
             mem_vals[int(mem_val[0][0], 16)] = int(mem_val[0][1], 16)
@@ -458,11 +457,28 @@ class instructionObject():
         : param instr_vars: Dictionary holding the values of current instruction state
         : param trap_dict : Values for the trap registers for current instruction 
         '''
+
         instr_vars['mode_change']   = trap_dict['mode_change']
-        instr_vars['exc_num']       = trap_dict['exc_num']
         instr_vars['call_type']     = trap_dict['call_type']
-        instr_vars['tval']          = trap_dict['tval']
-        
+
+        if trap_dict["mode_change"] is not None:
+            #update the registers depending upon the mode change
+            if trap_dict["mode_change"].split()[2] == "M":
+                instr_vars['mcause']      = trap_dict['exc_num']
+                instr_vars['mtval']       = trap_dict['tval']
+                instr_vars['scause']      = '0'
+                instr_vars['stval']       = '0'
+            elif trap_dict["mode_change"].split()[2] == "S":
+                instr_vars['scause']      = trap_dict['exc_num']
+                instr_vars['stval']       = trap_dict['tval']
+                instr_vars['mcause']      = '0'
+                instr_vars['mtval']       = '0'
+        else:
+                instr_vars['mcause']      = '0'
+                instr_vars['mtval']       = '0'
+                instr_vars['scause']      = '0'
+                instr_vars['stval']       = '0'
+
         return None
 
     '''

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -26,18 +26,18 @@ unsgn_rs1 = ['sw','sd','sh','sb','ld','lw','lwu','lh','lhu','lb', 'lbu','flw','f
         'bset','zext.h','sext.h','sext.b','zext.b','zext.w','minu','maxu','orc.b','add.uw','sh1add.uw',\
         'sh2add.uw','sh3add.uw','slli.uw','clz','clzw','ctz','ctzw','cpop','cpopw','rev8',\
         'bclri','bexti','binvi','bseti','fcvt.d.wu','fcvt.s.wu','fcvt.d.lu','fcvt.s.lu','c.flwsp',\
-        'c.not', 'c.sext.b','c.sext.h','c.zext.b','c.zext.h','c.zext.w','sc.w','lr.w']
+        'c.not', 'c.sext.b','c.sext.h','c.zext.b','c.zext.h','c.zext.w','sc.w','lr.w','sc.d','lr.d']
 unsgn_rs2 = ['bgeu', 'bltu', 'sltiu', 'sltu', 'sll', 'srl', 'sra','mulhu',\
         'mulhsu','divu','remu','divuw','remuw','aes64ds','aes64dsm','aes64es',\
         'aes64esm','aes64ks2','sm4ed','sm4ks','ror','rol','rorw','rolw','clmul',\
         'clmulh','clmulr','andn','orn','xnor','pack','packh','packu','packuw','packw',\
         'xperm.n','xperm.b', 'aes32esmi', 'aes32esi', 'aes32dsmi', 'aes32dsi',\
         'sha512sum1r','sha512sum0r','sha512sig1l','sha512sig1h','sha512sig0l','sha512sig0h','fsw',\
-        'bclr','bext','binv','bset','minu','maxu','add.uw','sh1add.uw','sh2add.uw','sh3add.uw', 'sc.w']
+        'bclr','bext','binv','bset','minu','maxu','add.uw','sh1add.uw','sh2add.uw','sh3add.uw','sc.w', 'sc.d']
 f_instrs_pref = ['fadd', 'fclass', 'fcvt', 'fdiv', 'feq', 'fld', 'fle', 'flt', 'flw', 'fmadd',\
         'fmax', 'fmin', 'fmsub', 'fmul', 'fmv', 'fnmadd', 'fnmsub', 'fsd', 'fsgnj', 'fsqrt',\
         'fsub', 'fsw']
-unsgn_rd = ['lr.w','sc.w']
+unsgn_rd = ['lr.w','sc.w','lr.d','sc.d']
 
 
 instr_var_evaluator_funcs = {} # dictionary for holding registered evaluator funcs
@@ -323,8 +323,8 @@ class instructionObject():
         csr_commit = self.csr_commit
         if csr_commit is not None:
             for commit in csr_commit:
-                if (commit[0] == "CSR") and commit[2] != '->':
-                    csr_regfile[commit[1]] = str(commit[3][2:])
+                if (commit[0] == "CSR"):
+                    csr_regfile[commit[1]] = str(commit[2][2:])
 
         mem_val = self.mem_val
         if mem_val is not None:

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -85,7 +85,8 @@ class instructionObject():
         mnemonic = None,
         mode = None,
         vm_addr_dict = None,
-        mem_val =  None
+        mem_val =  None,
+        trap_dict = None
     ):
 
         '''
@@ -128,6 +129,8 @@ class instructionObject():
         self.vm_addr_dict = vm_addr_dict
         self.matches_for_options = None
         self.mem_val = mem_val
+        self.trap_dict = trap_dict
+
     def is_sig_update(self):
         return self.instr_name in instrs_sig_update
 
@@ -169,6 +172,9 @@ class instructionObject():
             instr_vars['imm_val'] = self.shamt
 
         imm_val = instr_vars.get('imm_val', None)
+
+        #Update the values for the trap registers
+        self.trap_registers_update(instr_vars,self.trap_dict)
 
         # capture the register operand values
         rs1_val = self.evaluate_instr_var("rs1_val", instr_vars, arch_state)
@@ -443,6 +449,20 @@ class instructionObject():
                 iptw_dict[f'iptw{i}cont'] = None
             iptw_dict['len_iptw'] = 0
 
+        return None
+    
+    def trap_registers_update(self, instr_vars, trap_dict):
+        '''
+        This function updates the registers related to traps
+        in the log.
+        : param instr_vars: Dictionary holding the values of current instruction state
+        : param trap_dict : Values for the trap registers for current instruction 
+        '''
+        instr_vars['mode_change']   = trap_dict['mode_change']
+        instr_vars['exc_num']       = trap_dict['exc_num']
+        instr_vars['call_type']     = trap_dict['call_type']
+        instr_vars['tval']          = trap_dict['tval']
+        
         return None
 
     '''

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -85,6 +85,7 @@ class instructionObject():
         mnemonic = None,
         mode = None,
         vm_addr_dict = None,
+        mem_val =  None
     ):
 
         '''
@@ -126,6 +127,7 @@ class instructionObject():
         self.mode = mode
         self.vm_addr_dict = vm_addr_dict
         self.matches_for_options = None
+        self.mem_val = mem_val
     def is_sig_update(self):
         return self.instr_name in instrs_sig_update
 
@@ -279,13 +281,15 @@ class instructionObject():
         return changed_regs
 
 
-    def update_arch_state(self, arch_state, csr_regfile, iptw_dict):
+    def update_arch_state(self, arch_state, csr_regfile, iptw_dict, mem_vals):
         '''
         This function updates the arch state and csr regfiles
         with the effect of this instruction.
 
         :param csr_regfile: Architectural state of CSR register files
         :param instr_vars: Dictionary to be populated by the evaluated instruction variables
+        :param iptw_dict: Dictionary holding the values of PTW addresses for current instruction
+        :param mem_vals: Dictionary to be populated for the memory values
         '''
         arch_state.pc = self.instr_addr
 
@@ -303,6 +307,10 @@ class instructionObject():
                     csr_regfile[commit[1]] = str(commit[3][2:])
 
         self.iptw_update(iptw_dict)
+
+        mem_val = self.mem_val
+        if mem_val is not None:
+            mem_vals[int(mem_val[0][0], 16)] = int(mem_val[0][1], 16)
 
     def evaluate_instr_var(self, instr_var_name, *args):
         '''

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -1039,14 +1039,12 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                         return 1
                     elif prop_name_lower == 'd' and (pte_per & 0x80 != 0):
                         return 1
-                    elif prop_name_lower in {'rsw', 'RSW'} and (pte_per & 0x300 in {0, 1, 2, 3}):
-                        return 1
                     else:
-                        return None
+                        return 0
 
                 else:
                     return None
-            print(instr_vars)
+
             globals()['get_addr'] = check_label_address
             globals()['get_mem_val'] = get_mem_val
             globals()['get_pte_per'] = get_pte

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -1006,7 +1006,12 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                     else:
                         return None
 
-            def get_pte_per(pa, pte_addr, pgtb_addr, pte_size):
+            def get_pte_per(pa, pte_addr, pgtb_addr):
+                for match in matches_for_options:
+                    if match[0] == 'VM' and match[1] in ['SV39', 'SV48', 'SV57']:
+                        pte_size = 8
+                    elif match[0] == 'VM' and match[1] in ['SV32']:
+                        pte_size = 4
                 if (pgtb_addr >> 12) == (pte_addr >> 12):
                     if ((pa >> 12) == (get_mem_val(pte_addr, pte_size) >> 10)):
                         return get_mem_val(pte_addr, pte_size) & 0x3FF

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -904,10 +904,10 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
     # List to hold hit coverpoints
     hit_covpts = []
     rcgf = copy.deepcopy(cgf)
-
-    if 'option' in (cgf['check_for_the_isac']['config'][0]):
-        pattern_for_options = r'option\s+(\w+)\s*=\s*(\w+)'
-        matches_for_options = re.findall(pattern_for_options, cgf['check_for_the_isac']['config'][0])
+    for i in cgf:
+        if 'option' in (cgf[i]['config'][0]):
+            pattern_for_options = r'option\s+(\w+)\s*=\s*(\w+)'
+            matches_for_options = re.findall(pattern_for_options, cgf[i]['config'][0])
 
     # Set of elements to monitor for tracking signature updates
     tracked_regs_immutable = set()

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -1006,8 +1006,18 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                     else:
                         return None
 
+            def get_pte_per(pa, pte_addr, pgtb_addr, pte_size):
+                if (pgtb_addr >> 12) == (pte_addr >> 12):
+                    if ((pa >> 12) == (get_mem_val(pte_addr, pte_size) >> 10)):
+                        return get_mem_val(pte_addr, pte_size) & 0x3FF
+                    else:
+                        return None
+                else:
+                    return None
+
             globals()['get_addr'] = check_label_address
             globals()['mem_val'] = get_mem_val
+            globals()['get_pte_per'] = get_pte_per
 
             if enable :
                 ucovpt = []
@@ -1163,7 +1173,8 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                                                         "write": write_fn_csr_comb_covpt,
                                                         "read_csr": read_fn_csr_comb_covpt,
                                                         "get_addr": check_label_address,
-                                                        "mem_val":get_mem_val
+                                                        "mem_val":get_mem_val,
+                                                        "get_pte_per":get_pte_per
                                                     },
                                                     instr_vars
                                                 ):
@@ -1193,7 +1204,8 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                                                     "write": write_fn_csr_comb_covpt,
                                                     "read_csr": read_fn_csr_comb_covpt,
                                                     "get_addr": check_label_address,
-                                                    "mem_val":get_mem_val
+                                                    "mem_val":get_mem_val,
+                                                    "get_pte_per":get_pte_per
                                                 },
                                                 instr_vars
                                             ):

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -1165,16 +1165,6 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                                         simd_val_unpack(value['val_comb'], op_width, "rs2", rs2_val, lcls)
                                     instr_vars.update(lcls)
                                     for coverpoints in value['val_comb']:
-                                        pattern_imm = r'\bimm_val\b'
-                                        pattern_rs1 = r'\brs1_val\b'
-                                        pattern_rs2 = r'\brs2_val\b'
-                                        match_imm = bool(re.search(pattern_imm, coverpoints))
-                                        match_rs1 = bool(re.search(pattern_rs1, coverpoints))
-                                        match_rs2 = bool(re.search(pattern_rs2, coverpoints))
-                                        if (instr_vars['rs2_val'] == None) and match_rs2:
-                                            continue
-                                        if ('imm_val' not in instr_vars) and match_imm:
-                                            continue
                                         if eval(coverpoints, globals(), instr_vars):
                                             if cgf[cov_labels]['val_comb'][coverpoints] == 0:
                                                 ucovpt.append(str(coverpoints))

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -991,24 +991,13 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
             csr_write_vals = {}
             if instr.csr_commit is not None:
                 for commit in instr.csr_commit:
-                    if commit[0] == "CSR" and commit[4] and commit[2] == '<-':
-                        csr_write_vals[commit[1]] = int(commit[4],16)
+                    if commit[0] == "CSR" and commit[3]:
+                        csr_write_vals[commit[1]] = int(commit[3],16)
             def write_fn_csr_comb_covpt(csr_reg):
                 if csr_reg in csr_write_vals:
                     return csr_write_vals[csr_reg]
                 else:
                     return int(csr_regfile[csr_reg],16)
-                
-            csr_read_vals = {}
-            if instr.csr_commit is not None:
-                for csr_commit in instr.csr_commit:
-                    if(csr_commit[0] == "CSR") and (csr_commit[3]) and (csr_commit[2] == '->'):
-                        csr_read_vals[csr_commit[1]] = int(csr_commit[3],16)
-            def read_fn_csr_comb_covpt(csr_reg):
-                if instr.csr_commit is not None and csr_reg in csr_read_vals:
-                    return csr_read_vals.get(csr_reg)
-                else:
-                    return None
 
             def check_label_address(label):
                 return utils.collect_label_address(elf, label)
@@ -1211,7 +1200,6 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                                                         "__builtins__":None,
                                                         "old": old_fn_csr_comb_covpt,
                                                         "write": write_fn_csr_comb_covpt,
-                                                        "read_csr": read_fn_csr_comb_covpt,
                                                         "get_addr": check_label_address,
                                                         "get_mem_val":get_mem_val,
                                                         "get_pte":get_pte,
@@ -1243,7 +1231,6 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                                                     "__builtins__":None,
                                                     "old": old_fn_csr_comb_covpt,
                                                     "write": write_fn_csr_comb_covpt,
-                                                    "read_csr": read_fn_csr_comb_covpt,
                                                     "get_addr": check_label_address,
                                                     "get_mem_val":get_mem_val,
                                                     "get_pte":get_pte,

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -866,7 +866,7 @@ def simd_val_unpack(val_comb, op_width, op_name, val, local_dict):
     if simd_size == op_width:
         local_dict[f"{op_name}_val"]=elm_val
 
-def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr_pairs, sig_addrs, stats, arch_state, csr_regfile, no_count):
+def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr_pairs, sig_addrs, stats, arch_state, csr_regfile, no_count, elf):
     '''
     This function checks if the current instruction under scrutiny matches a
     particular coverpoint of interest. If so, it updates the coverpoints and
@@ -982,7 +982,8 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                     return csr_read_vals.get(csr_reg)
                 else:
                     return None
-
+            def check_label_address(label):
+                return utils.collect_label_address(elf, label)
 
             if enable :
                 ucovpt = []
@@ -1136,7 +1137,8 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                                                         "__builtins__":None,
                                                         "old": old_fn_csr_comb_covpt,
                                                         "write": write_fn_csr_comb_covpt,
-                                                        "read_csr": read_fn_csr_comb_covpt
+                                                        "read_csr": read_fn_csr_comb_covpt,
+                                                        "get_addr": check_label_address
                                                     },
                                                     instr_vars
                                                 ):
@@ -1419,7 +1421,7 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
         stats_queue.close()
 
 def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, flen, addr_pairs
-        , dump, cov_labels, sig_addrs, window_size, no_count=False, procs=1):
+        , dump, cov_labels, sig_addrs, window_size, elf, no_count=False, procs=1):
     '''Compute the Coverage'''
 
     global arch_state
@@ -1520,7 +1522,8 @@ def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xle
                                     stats,
                                     arch_state,
                                     csr_regfile,
-                                    no_count
+                                    no_count,
+                                    elf
                                     )
                             )
                         )

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -1117,6 +1117,19 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                                                 break
                                         if is_csr_commit:
                                             for coverpoints in value['csr_comb']:
+                                                def get_key_from_value(dictionary, target_value):
+                                                    for key, value in dictionary.items():
+                                                        if value == target_value:
+                                                            return key
+                                                    return None
+                                                #check the old_csr_value only for the register of interest
+                                                pattern_csr = r'old\("([^"]+)"\)'
+                                                match = re.search(pattern_csr, coverpoints)
+                                                if match:
+                                                    required_csr = match.group(1)
+                                                    key = get_key_from_value(csr_reg_num_to_str, required_csr)
+                                                    if (instr.csr != key):
+                                                        continue
                                                 if eval(
                                                     coverpoints,
                                                     {

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -1047,7 +1047,7 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
 
             globals()['get_addr'] = check_label_address
             globals()['get_mem_val'] = get_mem_val
-            globals()['get_pte_per'] = get_pte
+            globals()['get_pte'] = get_pte
             globals()['get_pte_prop'] = get_pte_prop
 
             if enable :

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -1246,7 +1246,7 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                                 tracked_regs_immutable.remove(csr_reg)
                                 del instr_addr_of_tracked_reg[csr_reg]
                         else:
-                            if rd in tracked_regs_immutable or rd in tracked_regs_mutable:
+                            if (rd in tracked_regs_immutable or rd in tracked_regs_mutable) and rd != 'x0':
                                 stat_meta = instr_stat_meta_at_addr[instr_addr_of_tracked_reg[rd]]
                                 stat_meta[3] -= 1
                                 tracked_regs_immutable.discard(rd)

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -452,7 +452,7 @@ class cross():
 
                 del self.instr_stat_meta_at_addr[key_instr_addr]
 
-            instr.update_arch_state(self.arch_state, self.csr_regfile, self.iptw_dict, self.mem_vals)
+            instr.update_arch_state(self.arch_state, self.csr_regfile, self.mem_vals)
 
     def get_metric(self):
         return self.result
@@ -947,15 +947,18 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
 
             instr_vars = {}
             instr_vars['inxFlag'] = instr.inxFlg
-            instr.evaluate_instr_vars(xlen, flen, arch_state, csr_regfile, instr_vars)
 
+            #csr regfile track for the previous instruction(old_csr_regfile)
             old_csr_regfile = {}
             for i in csr_regfile.csr_regs:
                 old_csr_regfile[i] = int(csr_regfile[i],16)
             def old_fn_csr_comb_covpt(csr_reg):
                 return old_csr_regfile[csr_reg]
 
+            #update the arch state and csr_regfile for the current instruction
             instr.update_arch_state(arch_state, csr_regfile, mem_vals)
+            #update instr_vars using updated arch state and updated csr_regfile
+            instr.evaluate_instr_vars(xlen, flen, arch_state, csr_regfile, instr_vars)
 
             #update the state of trap registers in csr_reg file using instr_vars
             if instr_vars["mode_change"] is not None:  #change the state only on the instruction

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -948,6 +948,13 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
 
             instr.update_arch_state(arch_state, csr_regfile, mem_vals)
 
+            #update the state of trap registers in csr_reg file using instr_vars
+            if instr_vars["mode_change"] is not None:  #change the state only on the instruction
+                csr_regfile["mcause"] = instr_vars["mcause"]
+                csr_regfile["scause"] = instr_vars["scause"]
+                csr_regfile["mtval"] = instr_vars["mtval"]
+                csr_regfile["stval"] = instr_vars["stval"]
+
             if 'rs1' in instr_vars:
                 rs1 = instr_vars['rs1']
             if 'rs2' in instr_vars:

--- a/riscv_isac/isac.py
+++ b/riscv_isac/isac.py
@@ -37,7 +37,7 @@ def isac(output_file,elf ,trace_file, window_size, cgf, parser_name, decoder_nam
                 sig_addr.append((start_address,end_address))
     else:
         test_name = trace_file.rsplit(',',1)[0]
-    rpt = cov.compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, flen, test_addr, dump, cov_labels, sig_addr, window_size, no_count, procs)
+    rpt = cov.compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, flen, test_addr, dump, cov_labels, sig_addr, window_size, elf, no_count, procs)
     if output_file is not None and logging:
         logger.info('Coverage Report:')
         logger.info('\n\n' + rpt)

--- a/riscv_isac/isac.py
+++ b/riscv_isac/isac.py
@@ -4,6 +4,58 @@ from riscv_isac.log import logger
 import riscv_isac.utils as utils
 import riscv_isac.coverage as cov
 from elftools.elf.elffile import ELFFile
+import re
+from ruamel.yaml import YAML
+from ruamel import yaml
+
+yaml = YAML(typ="rt")
+yaml.default_flow_style = False
+yaml.explicit_start = True
+yaml.allow_unicode = True
+yaml.allow_duplicate_keys = False
+
+safe_yaml = YAML(typ="safe")
+safe_yaml.default_flow_style = False
+safe_yaml.explicit_start = True
+safe_yaml.allow_unicode = True
+safe_yaml.allow_duplicate_keys = False
+
+def replace_values(obj, placeholder_data):
+    if isinstance(obj, dict):
+        updated_dict = {}
+        for key, value in obj.items():
+            new_key = replace_values(key, placeholder_data)
+            new_value = replace_values(value, placeholder_data)
+            updated_dict[new_key] = new_value
+        return updated_dict
+    elif isinstance(obj, list):
+        updated_list = [replace_values(item, placeholder_data) for item in obj]
+        return updated_list
+    elif isinstance(obj, str):
+        # Check if the string matches the pattern "${.*}"
+        matches = re.findall(r'\${(.*?)}', obj)
+        for match in matches:
+            if match in placeholder_data:
+                obj = obj.replace(f'${{{match}}}', str(placeholder_data[match]))
+        return obj
+    return obj
+
+def preprocessing(cgf, header_file, cgf_macros):
+    logger.info("Preprocessing")
+    if header_file is not None:
+        with open(header_file, "r") as file:
+            from io import StringIO
+            string_stream = StringIO()
+            safe_yaml.dump(dict(safe_yaml.load(file)), string_stream)
+            output_str = string_stream.getvalue()
+            string_stream.close()
+            placeholder_data = yaml.load(output_str)
+            output_yaml = replace_values(cgf, placeholder_data['common'])
+            for mac in cgf_macros:
+                output_yaml = replace_values(output_yaml, placeholder_data[mac])
+            return output_yaml
+    else:
+        return cgf
 
 def isac(output_file,elf ,trace_file, window_size, cgf, parser_name, decoder_name, parser_path, decoder_path, detailed, test_labels,
         sig_labels, dump, cov_labels, xlen, flen, no_count, procs, logging=False):

--- a/riscv_isac/isac.py
+++ b/riscv_isac/isac.py
@@ -58,7 +58,7 @@ def preprocessing(cgf, header_file, cgf_macros):
         return cgf
 
 def isac(output_file,elf ,trace_file, window_size, cgf, parser_name, decoder_name, parser_path, decoder_path, detailed, test_labels,
-        sig_labels, dump, cov_labels, xlen, flen, inxFlg, no_count, procs, logging=False):
+        sig_labels, dump, cov_labels, xlen, flen, no_count, procs, *inxFlg, logging=False):
     test_addr = []
     sig_addr = []
     if parser_path:

--- a/riscv_isac/main.py
+++ b/riscv_isac/main.py
@@ -188,7 +188,7 @@ def coverage(elf,trace_file, header_file, window_size, cgf_file, detailed,parser
 )
 def merge(files,detailed,p,cgf_file,output_file,flen,xlen,log_redundant, header_file,cgf_macro):
     rpt = cov.merge_coverage(
-            files,preprocessing(expand_cgf(cgf_file,int(xlen),int(flen),log_redundant), header_file, cgf_macro),detailed,p)
+            files,preprocessing(Translate_cgf(expand_cgf(cgf_file,int(xlen),int(flen),log_redundant)), header_file, cgf_macro),detailed,p)
     if output_file is None:
         logger.info('Coverage Report:')
         logger.info('\n\n' + rpt)
@@ -221,7 +221,7 @@ def merge(files,detailed,p,cgf_file,output_file,flen,xlen,log_redundant, header_
 def normalize(cgf_file,output_file,xlen,flen,log_redundant,header_file,cgf_macro):
     logger.info("Writing normalized CGF to "+str(output_file))
     with open(output_file,"w") as outfile:
-        utils.dump_yaml(preprocessing(expand_cgf(cgf_file,int(xlen),int(flen),log_redundant), header_file, cgf_macro),outfile)
+        utils.dump_yaml(preprocessing(Translate_cgf(expand_cgf(cgf_file,int(xlen),int(flen),log_redundant)), header_file, cgf_macro),outfile)
 
 @cli.command(help = 'Setup the plugin which uses the information from RISCV Opcodes repository to decode.')
 @click.option('--url',

--- a/riscv_isac/main.py
+++ b/riscv_isac/main.py
@@ -13,6 +13,7 @@ from riscv_isac.log import logger
 import riscv_isac.utils as utils
 from riscv_isac.cgf_normalize import *
 import riscv_isac.coverage as cov
+from riscv_isac.plugins.translator_cgf import Translate_cgf
 
 @click.group()
 @click.version_option(prog_name="RISC-V ISA Coverage Generator",version=__version__)
@@ -146,7 +147,7 @@ def cli(verbose):
 
 def coverage(elf,trace_file, header_file, window_size, cgf_file, detailed,parser_name, decoder_name, parser_path, decoder_path,output_file, test_label,
         sig_label, dump,cov_label, cgf_macro, xlen, flen, no_count, procs, log_redundant):  
-    isac(output_file,elf,trace_file, window_size, preprocessing(expand_cgf(cgf_file,int(xlen),int(flen),log_redundant), header_file, cgf_macro), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
+    isac(output_file,elf,trace_file, window_size, preprocessing(Translate_cgf(expand_cgf(cgf_file,int(xlen),int(flen),log_redundant)), header_file, cgf_macro), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
             sig_label, dump, cov_label, int(xlen), int(flen), no_count, procs)
 
 @cli.command(help = "Merge given coverage files.")

--- a/riscv_isac/plugins/c_sail.py
+++ b/riscv_isac/plugins/c_sail.py
@@ -18,6 +18,7 @@ irrespective of their original size.')
         '\[\d*\]\s\[(?P<mode>.*?)\]:\s(?P<addr>[0-9xABCDEF]+)\s\((?P<instr>[0-9xABCDEF]+)\)\s*(?P<mnemonic>.*)')
     instr_pattern_c_sail_regt_reg_val = re.compile('(?P<regt>[xf])(?P<reg>[\d]+)\s<-\s(?P<val>[0-9xABCDEF]+)')
     instr_pattern_c_sail_csr_reg_val = re.compile('(?P<CSR>CSR|clint::tick)\s(?P<reg>[a-z0-9]+)\s(.*?)\s(?P<val>[0-9xABCDEF]+)(?:\s\(input:\s(?P<input_val>[0-9xABCDEF]+)\))?')
+    instr_pattern_c_sail_mem_val = re.compile('mem\[(?P<addr>[0-9xABCDEF]+)\]\s<-\s(?P<val>[0-9xABCDEF]+)')
     def extractInstruction(self, line):
         instr_pattern = self.instr_pattern_c_sail
         re_search = instr_pattern.search(line)
@@ -100,6 +101,14 @@ irrespective of their original size.')
 
         return (return_dict)
 
+    def extractMemVal(self, line):
+        instr_pattern = self.instr_pattern_c_sail_mem_val
+        mem_val = re.findall(instr_pattern, line)
+        if(len(mem_val) == 0):
+            return None
+        else:
+            return mem_val
+
     @plugins.parserHookImpl
     def __iter__(self):
         with open(self.trace) as fp:
@@ -111,5 +120,6 @@ irrespective of their original size.')
             reg_commit = self.extractRegisterCommitVal(line)
             csr_commit = self.extractCsrCommitVal(line)
             vm_addr_dict = self.extractVirtualMemory(line)
-            instrObj = instructionObject(instr, 'None', addr, reg_commit = reg_commit, csr_commit = csr_commit, mnemonic = mnemonic, mode = mode, vm_addr_dict = vm_addr_dict)
+            mem_val = self.extractMemVal(line)
+            instrObj = instructionObject(instr, 'None', addr, reg_commit = reg_commit, csr_commit = csr_commit, mnemonic = mnemonic, mode = mode, vm_addr_dict = vm_addr_dict, mem_val = mem_val)
             yield instrObj

--- a/riscv_isac/plugins/c_sail.py
+++ b/riscv_isac/plugins/c_sail.py
@@ -40,10 +40,12 @@ irrespective of their original size.')
         instr_pattern = self.instr_pattern_c_sail_regt_reg_val
         re_search = instr_pattern.search(line)
         if re_search is not None:
+            # print(line, re_search)
             rtype = re_search.group('regt')
             cval = re_search.group('val')
             if rtype =='f' and self.arch[1] == 32:
                 cval = cval[0:2]+cval[-8:]
+            # print(rtype, re_search.group('reg'), cval)
             return (rtype, re_search.group('reg'), cval)
         else:
             return None

--- a/riscv_isac/plugins/c_sail.py
+++ b/riscv_isac/plugins/c_sail.py
@@ -15,16 +15,16 @@ class c_sail(spec.ParserSpec):
 irrespective of their original size.')
 
     instr_pattern_c_sail= re.compile(
-        '\[\d*\]\s\[(.*?)\]:\s(?P<addr>[0-9xABCDEF]+)\s\((?P<instr>[0-9xABCDEF]+)\)\s*(?P<mnemonic>.*)')
+        '\[\d*\]\s\[(?P<mode>.*?)\]:\s(?P<addr>[0-9xABCDEF]+)\s\((?P<instr>[0-9xABCDEF]+)\)\s*(?P<mnemonic>.*)')
     instr_pattern_c_sail_regt_reg_val = re.compile('(?P<regt>[xf])(?P<reg>[\d]+)\s<-\s(?P<val>[0-9xABCDEF]+)')
     instr_pattern_c_sail_csr_reg_val = re.compile('(?P<CSR>CSR|clint::tick)\s(?P<reg>[a-z0-9]+)\s(.*?)\s(?P<val>[0-9xABCDEF]+)(?:\s\(input:\s(?P<input_val>[0-9xABCDEF]+)\))?')
     def extractInstruction(self, line):
         instr_pattern = self.instr_pattern_c_sail
         re_search = instr_pattern.search(line)
         if re_search is not None:
-            return int(re_search.group('instr'), 16),re_search.group('mnemonic')
+            return int(re_search.group('instr'), 16),re_search.group('mnemonic'),re_search.group('mode')
         else:
-            return None, None
+            return None, None, None
 
     def extractAddress(self, line):
         instr_pattern = self.instr_pattern_c_sail
@@ -60,9 +60,9 @@ irrespective of their original size.')
             content = fp.read()
         instructions = content.split('\n\n')
         for line in instructions:
-            instr, mnemonic = self.extractInstruction(line)
+            instr, mnemonic, mode = self.extractInstruction(line)
             addr = self.extractAddress(line)
             reg_commit = self.extractRegisterCommitVal(line)
             csr_commit = self.extractCsrCommitVal(line)
-            instrObj = instructionObject(instr, 'None', addr, reg_commit = reg_commit, csr_commit = csr_commit, mnemonic = mnemonic )
+            instrObj = instructionObject(instr, 'None', addr, reg_commit = reg_commit, csr_commit = csr_commit, mnemonic = mnemonic, mode = mode )
             yield instrObj

--- a/riscv_isac/plugins/c_sail.py
+++ b/riscv_isac/plugins/c_sail.py
@@ -17,12 +17,12 @@ irrespective of their original size.')
     instr_pattern_c_sail= re.compile(
         '\[\d*\]\s\[(.*?)\]:\s(?P<addr>[0-9xABCDEF]+)\s\((?P<instr>[0-9xABCDEF]+)\)\s*(?P<mnemonic>.*)')
     instr_pattern_c_sail_regt_reg_val = re.compile('(?P<regt>[xf])(?P<reg>[\d]+)\s<-\s(?P<val>[0-9xABCDEF]+)')
-    instr_pattern_c_sail_csr_reg_val = re.compile('(?P<CSR>CSR|clint::tick)\s(?P<reg>[a-z0-9]+)\s<-\s(?P<val>[0-9xABCDEF]+)(?:\s\(input:\s(?P<input_val>[0-9xABCDEF]+)\))?')
+    instr_pattern_c_sail_csr_reg_val = re.compile('(?P<CSR>CSR|clint::tick)\s(?P<reg>[a-z0-9]+)\s(.*?)\s(?P<val>[0-9xABCDEF]+)(?:\s\(input:\s(?P<input_val>[0-9xABCDEF]+)\))?')
     def extractInstruction(self, line):
         instr_pattern = self.instr_pattern_c_sail
         re_search = instr_pattern.search(line)
         if re_search is not None:
-                return int(re_search.group('instr'), 16),re_search.group('mnemonic')
+            return int(re_search.group('instr'), 16),re_search.group('mnemonic')
         else:
             return None, None
 

--- a/riscv_isac/plugins/c_sail.py
+++ b/riscv_isac/plugins/c_sail.py
@@ -40,12 +40,10 @@ irrespective of their original size.')
         instr_pattern = self.instr_pattern_c_sail_regt_reg_val
         re_search = instr_pattern.search(line)
         if re_search is not None:
-            # print(line, re_search)
             rtype = re_search.group('regt')
             cval = re_search.group('val')
             if rtype =='f' and self.arch[1] == 32:
                 cval = cval[0:2]+cval[-8:]
-            # print(rtype, re_search.group('reg'), cval)
             return (rtype, re_search.group('reg'), cval)
         else:
             return None

--- a/riscv_isac/plugins/c_sail.py
+++ b/riscv_isac/plugins/c_sail.py
@@ -13,7 +13,7 @@ class c_sail(spec.ParserSpec):
         if arch[1] == 32:
             logger.warn('FLEN is set to 32. Commit values in the log will be terminated to 32 bits \
 irrespective of their original size.')
-
+    old_trap_dict = {"mode_change": None, "call_type": None, "exc_num": None, "tval": None}
     instr_pattern_c_sail= re.compile(
         '\[\d*\]\s\[(?P<mode>.*?)\]:\s(?P<addr>[0-9xABCDEF]+)\s\((?P<instr>[0-9xABCDEF]+)\)\s*(?P<mnemonic>.*)')
     instr_pattern_c_sail_regt_reg_val = re.compile('(?P<regt>[xf])(?P<reg>[\d]+)\s<-\s(?P<val>[0-9xABCDEF]+)')
@@ -79,7 +79,7 @@ irrespective of their original size.')
             dptw_list=(mem_r_pattern.findall(line_lower_part))
 
             if dptw_list is not None:
-                if "lw" in match_search_mnemonic.group('mnemonic'):
+                if "lw" in match_search_mnemonic.group('mnemonic') and dptw_list:
                     depa_list=dptw_list.pop()
                     depa=int(depa_list[0],16)
                 else:
@@ -119,7 +119,11 @@ irrespective of their original size.')
             trap_dict["call_type"]   = instr_trap_pattern.group("call_type")
             trap_dict["exc_num"]     = instr_trap_pattern.group("exc_num")
             trap_dict["tval"]        = instr_trap_pattern.group("tval")
+            self.old_trap_dict = trap_dict
 
+        #maintain the value if None
+        if instr_trap_pattern is None:
+            trap_dict = self.old_trap_dict
         return trap_dict
 
     @plugins.parserHookImpl

--- a/riscv_isac/plugins/c_sail.py
+++ b/riscv_isac/plugins/c_sail.py
@@ -117,9 +117,9 @@ irrespective of their original size.')
         if instr_trap_pattern:
             trap_dict["mode_change"] = instr_trap_pattern.group("mode_change")
             trap_dict["call_type"]   = instr_trap_pattern.group("call_type")
-            trap_dict["exc_num"]     = int(instr_trap_pattern.group("exc_num"),16)
-            trap_dict["tval"]        = int(instr_trap_pattern.group("tval"),16)
-        
+            trap_dict["exc_num"]     = instr_trap_pattern.group("exc_num")
+            trap_dict["tval"]        = instr_trap_pattern.group("tval")
+
         return trap_dict
 
     @plugins.parserHookImpl

--- a/riscv_isac/plugins/c_sail.py
+++ b/riscv_isac/plugins/c_sail.py
@@ -17,7 +17,7 @@ irrespective of their original size.')
     instr_pattern_c_sail= re.compile(
         '\[\d*\]\s\[(?P<mode>.*?)\]:\s(?P<addr>[0-9xABCDEF]+)\s\((?P<instr>[0-9xABCDEF]+)\)\s*(?P<mnemonic>.*)')
     instr_pattern_c_sail_regt_reg_val = re.compile('(?P<regt>[xf])(?P<reg>[\d]+)\s<-\s(?P<val>[0-9xABCDEF]+)')
-    instr_pattern_c_sail_csr_reg_val = re.compile('(?P<CSR>CSR|clint::tick)\s(?P<reg>[a-z0-9]+)\s(.*?)\s(?P<val>[0-9xABCDEF]+)(?:\s\(input:\s(?P<input_val>[0-9xABCDEF]+)\))?')
+    instr_pattern_c_sail_csr_reg_val = re.compile('(?P<CSR>CSR|clint::tick)\s(?P<reg>[a-z0-9]+)\s<-\s(?P<val>[0-9xABCDEF]+)(?:\s\(input:\s(?P<input_val>[0-9xABCDEF]+)\))?')
     instr_pattern_c_sail_mem_val = re.compile('mem\[(?P<addr>[0-9xABCDEF]+)\]\s<-\s(?P<val>[0-9xABCDEF]+)')
     instr_pattern_c_sail_trap = re.compile(r'trapping\sfrom\s(?P<mode_change>\w+\sto\s\w+)\sto\shandle\s(?P<call_type>\w+.*)\shandling\sexc#(?P<exc_num>0x[0-9a-fA-F]+)\sat\spriv\s\w\swith\stval\s(?P<tval>0x[0-9a-fA-F]+)')
     def extractInstruction(self, line):

--- a/riscv_isac/plugins/translator_cgf.py
+++ b/riscv_isac/plugins/translator_cgf.py
@@ -1,0 +1,749 @@
+#Translator -- (cgf/yaml based file --> cgf)
+import os
+import re
+import math
+import yaml
+from riscv_isac.log import logger
+
+class Translator:
+    """A class for translating YAML data and generating coverpoints."""
+
+    def __init__(self):
+        """Initialize the Translator object."""
+        self.defs_data = None
+        self.data_yaml = None
+        self.replacement_dict = {}
+        self.replacement_dict_resolved = {}
+        self.number_replace_order = {}
+        self.curr_cov = None
+        self.label = None
+        self.list_braces = []
+        self.current_coverpoint_track = 0
+
+        self.braces_finder              = re.compile(r'({.*?})')
+        self.multi_brace_finder         = re.compile(r'({\s*{.*?}.*?})')
+        self.macro_def_finder           = re.compile(r'(\${.*?})') # ${variable}To ignore any such definition
+        self.number_brace_finder        = re.compile(r'(\$\d+)')   # $1
+        self.macro_brace_resolver       = re.compile(r'(\%\d+)')   # 
+        self.repeat_brace_index         = re.compile(r'(\*\d+)')
+        self.list_brace_finder          = re.compile(r'\{([^}]*)\}\{(\[[^\]]+\])\}')
+        self.list_index_brace_finder    = re.compile(r'(\{\[.*?\]\})')
+        self.list_index_number_finder   = re.compile(r'(\<\<[^>]*\>\>\{\[[^\]]+\]\})')
+        self.placeholder_pattern        = re.compile(r'<<MULTI\d+>>|<<SINGLE\d+>>|<<COMMA\d+>>|<<LIST\d+>>')
+        self.resolve_back_order         = re.compile(r'<<MULTI\d+>>|<<SINGLE\d+>>|<<COMMA\d+>>')
+
+    def translate_using_path(self, input_path, output_path):
+        """Translate YAML data from the input file and dump it into the output file.
+        
+        Args:
+            input_path (str): Path to the input YAML file.
+            output_path (str): Path to save the translated YAML data.
+        """
+        self.load_yaml(input_path)
+        self.evaluate_cp()
+        self.dump_data(output_path, self.data_yaml)
+
+    def translate(self, loaded_cgf):
+        """Translate YAML data from the input cgf and return the translated_cgf.
+        
+        Args:
+            input_path (str): Loaded cgf.
+        """
+        self.defs_data = loaded_cgf
+        self.evaluate_cp()
+        return self.data_yaml
+
+    def load_yaml(self, input_path):
+        """Load YAML data from the given file path.
+
+        Args:
+            input_path (str): Path to the YAML file to load.
+
+        Raises:
+            FileNotFoundError: If the specified file is not found.
+        """
+        if not os.path.exists(input_path):
+            raise FileNotFoundError(f"{input_path} does not exist.")
+        try:
+            with open(input_path, 'r') as file:
+                yaml_data = yaml.safe_load(file)
+            self.defs_data = yaml_data
+        except Exception as e:
+            print(f"Failed to load YAML file: {e}")
+
+    def dump_data(self, output_path, yaml_data):
+        """Dump the given YAML data into the specified file.
+
+        Args:
+            output_path (str): Path to save the YAML data.
+            yaml_data (dict): YAML data to be dumped.
+
+        Raises:
+            Exception: If an error occurs while writing data to the file.
+        """
+        try:
+            with open(output_path, 'w') as file:
+                yaml.dump(yaml_data, file)
+        except Exception as e:
+            print(f"Failed to write data to file: {e}")
+
+    def evaluate_cp(self):
+        """Evaluate coverpoints based on the loaded YAML data."""
+        self.data_yaml = {}
+        for curr_cov in self.defs_data:
+            self.data_yaml[curr_cov] = {}  # Initialize a new coverpoint dictionary for current coverage point
+            for label in self.defs_data[curr_cov]:
+                self.finder(curr_cov,label)
+
+    def finder(self, curr_cov, label):
+        """
+        Find combinations/rules in a single line and solve them using multiple solvers.
+
+        Args:
+            curr_cov (str): The current coverpoint.
+            label (str): The label within the coverpoint.
+
+        Returns:
+            None
+        """
+        self.curr_cov = curr_cov
+        self.label = label
+        line = self.defs_data[curr_cov][label]
+        if isinstance(line, dict):
+            for instr in line:
+                # Clean replacement dict on every iteration
+                self.replacement_dict = {}
+
+                # Process macros
+                instr = self.replace_macros(instr)
+
+                # Process the list-braces
+                instr = self.replace_list_braces(instr)
+
+                # Process multibraces
+                instr = self.replace_multibraces(instr)
+
+                # Process single braces and comma-separated values
+                instr = self.replace_braces_commas(instr)
+
+                # Process $number placeholders
+                instr = self.replace_number_placeholders(instr)
+
+                # Check the order of every brace and maintain with the $number placeholder
+                place_holder_pattern = self.replace_order_pattern(instr)
+
+                # Resolve every brace found in the string
+
+                # Resolve the single braces and multi_internal braces
+                self.resolve_single_brace(self.replacement_dict)
+
+                # Resolve the multibraces
+                self.resolve_multibraces(self.replacement_dict)
+
+                # Resolve the comma separated
+                self.resolve_comma_brace(self.replacement_dict)
+
+                # Resolve list-braces 
+                self.resolve_list_braces(self.replacement_dict)
+
+                # Substitute the values in the coverpoint
+
+                #Pass the values to controller to resolve all the coverpoints
+                self.loop_controller(instr, self.replacement_dict, place_holder_pattern)
+
+                # Complete the coverpoint process
+                # self.calculate_coverpoints(instr, self.replacement_dict, place_holder_pattern)
+
+                # If there is no substitution, then generate
+                if len(self.replacement_dict) == 0:
+                    self.generator(curr_cov, label, instr, 1)
+
+        # Generate the coverpoint not of interest
+        else:
+            self.generator(curr_cov, label, line, 0)
+
+    def replace_macros(self, instr):
+        """
+        Replace macros in the instruction with placeholders.
+
+        Args:
+            instr (str): The instruction string.
+            macros (list): List of macros to replace.
+
+        Returns:
+            str: The instruction string with macros replaced.
+        """
+
+        macros = self.macro_def_finder.findall(instr)
+        macro_dict = {macro: f'<<MACRO{index}>>' for index, macro in enumerate(macros)}
+        instr, replacements = self.replace_using_dict(instr, macro_dict)
+        self.replacement_dict.update(replacements)
+        return instr
+    
+    def replace_multibraces(self, instr):
+        """
+        Replace multibraces in the instruction with placeholders.
+
+        Args:
+            instr (str): The instruction string containing multibraces.
+
+        Returns:
+            str: The instruction string with multibraces replaced.
+        """
+        replacements = {}
+        global_multi_index = 0
+
+        def replace_braces(match, instr_string):
+            nonlocal replacements, global_multi_index
+            instr = instr_string
+            multi_braces = match.group(0)
+            internal_braces = self.braces_finder.findall(multi_braces[1:-1])
+            for index, brace in enumerate(internal_braces):
+                placeholder = f'<<MULTI_INTER{global_multi_index}>>'
+                instr = instr.replace(brace, placeholder)
+                replacements[placeholder] = brace
+            placeholder = f'<<MULTI{global_multi_index}>>'
+            instr = instr.replace(multi_braces, placeholder)
+            replacements[placeholder] = multi_braces
+            global_multi_index += 1
+            return placeholder
+
+        instr = re.sub(self.multi_brace_finder, lambda match: replace_braces(match, instr), instr)
+        self.replacement_dict.update(replacements)
+        return instr
+
+    def replace_braces_commas(self, instr):
+        """
+        Replace single braces and comma-separated values in the instruction with placeholders.
+
+        Args:
+            instr (str): The instruction string containing single braces and comma-separated values.
+
+        Returns:
+            str: The instruction string with single braces and comma-separated values replaced.
+        """
+        braces = self.braces_finder.findall(instr)
+        comma  = [val for val in braces if "..." not in val and "," in val]
+        braces = [val for val in braces if "..." in val]
+        comma_dict = {val: f'<<COMMA{index}>>' for index, val in enumerate(comma)}
+        single_dict = {val: f'<<SINGLE{index}>>' for index, val in enumerate(braces)}
+        instr, replacements = self.replace_using_dict(instr, {**comma_dict, **single_dict})
+        self.replacement_dict.update(replacements)
+        return instr
+    
+    def replace_number_placeholders(self, instr):
+        """
+        Replace $number placeholders in the instruction string with unique placeholders.
+
+        Args:
+            instr (str): The instruction string containing $number placeholders.
+
+        Returns:
+            str: The instruction string with $number placeholders replaced.
+        """
+        # Create a dictionary to store the replacements for each unique $number
+        replace_dict = {}
+        for index, match in enumerate(self.number_brace_finder.finditer(instr)):
+            number = match.group(0)
+            # If the number is encountered for the first time, create a new placeholder
+            if number not in replace_dict:
+                replace_dict[number] = f'<<NUMBER{len(replace_dict)}>>'
+        # Use the replace_using_dict method to perform the replacements
+        instr, replacements = self.replace_using_dict(instr, replace_dict)
+        # Update the replacement dictionary with the placeholders and their original values
+        self.replacement_dict.update(replacements)
+        return instr
+
+    def replace_list_braces(self, instr):
+        """
+        Replace list braces and their contents in the instruction with placeholders.
+
+        Args:
+            instr (str): The instruction string containing list braces and their contents.
+
+        Returns:
+            str: The instruction string with list braces and their contents replaced.
+        """
+        list_braces = self.list_brace_finder.findall(instr)
+        replacements = {}
+        for index, brace in enumerate(list_braces):
+
+            brace_content, brace_index = brace[0], brace[1]
+            placeholder_brace = f'<<LIST{index}>>'
+            instr = instr.replace(f'{{{brace_content}}}', placeholder_brace)
+
+            # Check if the placeholders already exist in replacements
+            if (f'{{{brace_content}}}' not in replacements.values()) or (f'{{{brace_index}}}' not in replacements.values()):
+                replacements[placeholder_brace] = f'{{{brace_content}}}'
+
+        # Update the replacement dictionary
+        self.replacement_dict.update(replacements)
+
+        return instr
+
+
+    def resolve_single_brace(self, replacement_dict):
+        """
+        Resolve single braces and multi_internal braces in the replacement dictionary.
+
+        Args:
+            replacement_dict (dict): A dictionary containing keys with placeholders and values to be resolved.
+
+        Raises:
+            ValueError: If the input for a placeholder is invalid or if digits are not found in the value.
+
+        Returns:
+            None
+        """
+        for key, val in replacement_dict.items():
+            if ("MULTI_INTER" in key or "SINGLE" in key ): #solve the comma seperated digits as well
+                digits = re.findall(r'\d+', val)
+                comma_sep_num = re.findall(r'\{\d+(?:, \d+)*\}', val)
+                if digits:
+                    if len(digits) == 2 and int(digits[0]) <= int(digits[1]):
+                        start, end = map(int, digits)
+                        result = list(range(start, end + 1))
+                        replacement_dict[key] = result
+                    elif len(digits) > 2 and comma_sep_num:
+                            values = list(map(int, digits))
+                            replacement_dict[key] = values
+                    else:
+                        raise ValueError(f"Invalid input for key {val}: Expected a valid range of integers")
+                else:
+                    raise ValueError(f"Digits not found in the value for key {val}.")
+
+        self.replacement_dict = replacement_dict
+
+
+    def resolve_list_braces(self, replacement_dict):
+
+        for key, val in replacement_dict.items():
+            if ("LIST" in key) and (not "LIST_INDEX" in key):
+                val_list = [num.strip() if num.strip().isdigit() else num.strip() for num in val[1:-1].split(',')]
+                repeat_list = [value for value in val_list if "..." in value]
+
+                for curr_val in repeat_list:
+                    numbers = re.findall(r'\d+', curr_val)
+                    number_list = [str(i) for i in range(int(numbers[0]), int(numbers[1])+1)]
+                    req_index = val_list.index(curr_val)
+                    val_list = val_list[:req_index] + number_list + val_list[req_index+1:]
+                    val_list.extend([item for item in number_list if item not in val_list])
+
+                replacement_dict[key] = val_list
+
+        self.replacement_dict = replacement_dict
+
+    def resolve_multibraces(self, replacement_dict):
+        """
+        Resolve multibraces in the replacement dictionary.
+
+        Args:
+            replacement_dict (dict): A dictionary containing keys with placeholders and values to be resolved.
+
+        Raises:
+            ValueError: If the range pattern is not found in the value, if the start of the range is greater than the end,
+                if an invalid operation is specified, or if the digit value is invalid.
+
+        Returns:
+            None
+        """
+        for key, val in replacement_dict.items():
+            if "MULTI" in key and not "MULTI_INTER" in key :
+                range_match = re.search(r'{(\d+)\s*\.\.\.\s*(\d+)}', val)
+                operation_match = re.search(r'([+\-*/%]|<<|>>)\s*(\d+)', val)
+                comma_sep_num = re.findall(r'\{\d+(?:, \d+)*\}', val)
+                if range_match:
+                    start, end = map(int, range_match.groups())
+                    if start <= end:
+                        range_list = list(range(start, end + 1))
+                        if operation_match:
+                            operation, digit = operation_match.groups()
+                            try:
+                                digit = int(digit)
+                            except ValueError:
+                                raise ValueError(f"Invalid digit value for key {val}.")
+                            result_list = self.apply_operation(range_list, operation, digit)
+                            replacement_dict[key] = result_list
+                        else:
+                            raise ValueError(f"No operation found for key {val}!")
+                    else:
+                        raise ValueError(f"Invalid range for key {val}: Start must be less than or equal to end.")
+                elif comma_sep_num:
+                    internal_digits_list = re.findall(r'\d+', comma_sep_num[0])
+                    internal_digits_list = list(map(int, internal_digits_list))
+                    if operation_match:
+                        operation, digit = operation_match.groups()
+                        result_list = self.apply_operation(internal_digits_list, operation, digit)
+                        replacement_dict[key] = result_list
+                    else:
+                        raise ValueError(f"No operation found for key {val}!")
+                else:
+                    raise ValueError(f"Range pattern not found in the value for key {val}.")
+                
+        self.replacement_dict = replacement_dict
+
+    
+    def resolve_comma_brace(self, replacement_dict):
+        """
+        Resolve comma-separated values in the replacement dictionary.
+
+        Args:
+            replacement_dict (dict): A dictionary containing keys with placeholders and comma-separated values as strings.
+
+        Raises:
+            ValueError: If the comma pattern is invalid.
+
+        Returns:
+            None
+        """
+        for key, val in replacement_dict.items():
+            if "COMMA" in key and isinstance(val, str):
+                comma_pattern = r'{(.*?)}'
+                comma_match = re.findall(comma_pattern, val)
+                if comma_match:
+                    values = [value.strip() for value in comma_match[0].split(',')]
+                    replacement_dict[key] = values
+                else:
+                    raise ValueError(f"Invalid Comma Pattern for {val}")
+
+        self.replacement_dict = replacement_dict
+
+    def resolve_lists(self, instr_lst, replacement_dict, place_holder_pattern):
+        number_pattern = re.compile(r'\d+')
+        return_instr_lst = []
+
+        for instr in instr_lst:
+            req_element_list = []
+            list_index_matches = self.list_index_brace_finder.findall(instr)
+            resolved_list_index = self.list_index_resolver(list_index_matches)
+
+            for index, (key, val) in enumerate(replacement_dict.items()):
+                if "LIST" in key:
+                    try:
+                        req_element_list.append(val[resolved_list_index[index]])
+                    except IndexError as e:
+                        logging.error(f"Error: list index out of range. The index {resolved_list_index[index - 1]} is out of the size of the list {val} whose length is {len(val)}")
+                        break
+            
+            #Replace the list index with No space
+            for index, val in enumerate(req_element_list):
+                if list_index_matches[index] in instr:
+                    instr = instr.replace(list_index_matches[index], "")
+
+            temp_element_dict = {}
+            for index, (key, val) in enumerate(replacement_dict.items()):
+                if "LIST" in key:
+                    temp_element_dict[key] = req_element_list[index]
+                    instr = instr.replace(key, req_element_list[index])
+            
+            for (key, val) in replacement_dict.items():
+                if "NUMBER" in key:
+                    result = number_pattern.findall(val)
+                    result = int(result[0]) -1
+                    var = place_holder_pattern[result]
+                    if "LIST" in var:
+                        instr = instr.replace(key, temp_element_dict[var])
+            
+            return_instr_lst.append(instr)
+        return return_instr_lst
+
+    def loop_controller(self, instr, replacement_dict, place_holder_pattern):
+        current_cov_track = self.current_coverpoint_track
+        placeholders = self.resolve_back_order.findall(instr)
+        final_cov_list = []
+        gen_cov_list = []
+        req_fn_list = []
+
+        gen_cov_list.append(instr)
+        
+        #In case of only macro is present
+        if len(placeholders) == 0:
+            track_dict = {}
+            instr = self.generate_current_cov(instr, track_dict, replacement_dict, place_holder_pattern, req_fn_list)
+            final_cov_list.append(instr)
+        else:
+            for curr_resolve in placeholders:
+                req_fn_list = [placeholders[current_cov_track]]
+                temp_gen_cov_list = []
+
+                for instr in gen_cov_list:
+                    curr_generated_cov_list = self.calculate_coverpoints(instr, replacement_dict, place_holder_pattern, req_fn_list)
+                    temp_gen_cov_list.extend(curr_generated_cov_list)
+                #Remove the previous coverpoints and replace with the newly generated coverpoints
+                gen_cov_list = []
+                gen_cov_list.extend(temp_gen_cov_list)
+                current_cov_track +=1
+
+            #Append the completed generated coverpoint list to the final_cov_list
+            final_cov_list.extend(gen_cov_list)
+            
+
+            #Resolve the lists when everything is solved
+            final_cov_list = self.resolve_lists(final_cov_list, replacement_dict, place_holder_pattern)            
+
+        #Call the generator function after creating all the coverpoints
+        for coverpoint in final_cov_list:
+            self.generator(self.curr_cov, self.label, f"{coverpoint}", 1)
+
+    
+
+
+
+    def calculate_coverpoints(self, instr, replacement_dict, place_holder_pattern, req_fn_list):
+        """
+        Calculate coverpoints based on the provided instructions, replacement dictionary, and placeholder pattern.
+
+        Args:
+            instr (str): The instruction string.
+            replacement_dict (dict): A dictionary containing keys with placeholders and their corresponding values.
+            place_holder_pattern (list): A list containing the modified order of placeholders.
+
+        Returns:
+            None
+        """
+        # Create a Track Dictionary of the current variables
+        track_dict = {}
+        # Populate the dictionary with the proper indexes | only the req_fn_list
+        track_dict = self.initialize_track_dict(track_dict, replacement_dict) 
+
+        #required length of the coverpoints -> defined by the req_fn_list
+        max_len = len(replacement_dict[req_fn_list[0]])
+
+        gen_cov_list = []
+
+        for _ in range(max_len):
+            
+            # Generate coverpoint for current track
+            out_cov = self.generate_current_cov(instr, track_dict, replacement_dict, place_holder_pattern, req_fn_list)
+
+            # Update the state of the track_dict
+            track_dict = self.update_replacement_dict(track_dict)
+
+            gen_cov_list.append(out_cov)
+        
+        return gen_cov_list
+
+    def generate_current_cov(self, instr, track_dict, replacement_dict, place_holder_pattern, req_fn_list):
+        """
+        Generate coverpoints for the current instruction based on the track dictionary, replacement dictionary,
+        and placeholder pattern.
+
+        Args:
+            instr (str): The instruction string.
+            track_dict (dict): A dictionary containing the current track of variables.
+            replacement_dict (dict): A dictionary containing keys with placeholders and their corresponding values.
+            place_holder_pattern (list): A list containing the modified order of placeholders.
+
+        Returns:
+            str: The generated coverpoint.
+        """
+        
+        number_pattern = re.compile(r'\d+')
+
+        for key, val in replacement_dict.items():
+            check = False
+
+            #Resolve the MULTI_BRACES back
+            if (key in req_fn_list and "MULTI" in key):
+                check = True
+            if ("MULTI" in key and "MULTI_INTER" not in key) and check:
+                curr_index = track_dict[key][2]
+                instr = instr.replace(key, str(val[curr_index]))
+
+            #Resolve the Single braces back
+            if (key in req_fn_list and "SINGLE" in key):
+                check = True
+            if "SINGLE" in key and check:
+                curr_index = track_dict[key][2]
+                instr = instr.replace(key, str(val[curr_index]))
+
+            # Resolve the Comma Seperated back
+            if (key in req_fn_list and "COMMA" in key):
+                check = True
+            if "COMMA" in key and check:
+                curr_index = track_dict[key][2]
+                instr = instr.replace(key, str(val[curr_index]))
+
+            #Resolve the dependent placeholders
+            if "NUMBER" in key:
+                internal_list_index_number_finder   = re.compile(r'\<\<([^>]*)\>\>\{\[([^\]]+)\]\}')
+                list_index_pattern = self.list_index_number_finder.findall(instr)
+                result = int(number_pattern.findall(val)[0]) -1
+                var = place_holder_pattern[result]
+                curr_index = track_dict[var][2]
+
+                for index, val in enumerate(list_index_pattern):
+                    internal_list__index_pattern = internal_list_index_number_finder.findall(val)
+                    if key in internal_list__index_pattern[0][1]:
+                        req_val = f"<<{internal_list__index_pattern[0][0]}>>{{[{curr_index}{internal_list__index_pattern[0][1].replace(key, '')}]}}"
+                        instr = instr.replace(list_index_pattern[index], req_val)
+
+                if "MULTI_INTER" in var and "MULTI" in req_fn_list[0]:
+                    instr = instr.replace(key, str(replacement_dict[var][curr_index]))
+                if req_fn_list[0] in var:
+                    instr = instr.replace(key, str(replacement_dict[var][curr_index]))
+
+        # Resolve back the macros
+        for key, val in replacement_dict.items():
+            if "MACRO" in key:
+                instr = instr.replace(key, val)
+            
+        return instr
+
+    def generator(self, curr_cov, label, line, rule):
+        """
+        Generates the required coverpoint and appends it to the existing one in the data YAML.
+
+        Args:
+            curr_cov (str): The current coverpoint.
+            label (str): The label of the coverpoint.
+            line (str): The coverpoint line to be generated.
+            rule (int): The rule indicating whether to append to the existing coverpoint or create a new one.
+
+        Returns:
+            None
+        """
+        if rule == 0:
+            self.data_yaml[curr_cov][label] = line
+        elif rule == 1:
+            if label in self.data_yaml[curr_cov]:
+                self.data_yaml[curr_cov][label][line] = 0
+            else:
+                self.data_yaml[curr_cov][label] = {}
+                self.data_yaml[curr_cov][label][line] = 0
+
+
+
+    """Helper Functions"""
+    def replace_using_dict(self, instr, replace_dict):
+        """
+        Replace substrings in the instruction string based on the provided dictionary.
+
+        Args:
+            instr (str): The instruction string to perform replacements on.
+            replace_dict (dict): A dictionary containing substrings to replace as keys and their replacements as values.
+
+        Returns:
+            tuple: A tuple containing the modified instruction string and a dictionary of replacements made.
+        """
+        if not replace_dict:
+            return instr, {}
+        
+        replacements = {}
+        def replace(match):
+            replacement = replace_dict[match.group(0)]
+            replacements[replacement] = match.group(0)
+            return replacement
+        instr = re.sub('|'.join(map(re.escape, replace_dict.keys())), replace, instr)
+        return instr, replacements
+
+    def replace_order_pattern(self, instr):
+        """
+        Modify the order of placeholders in the instruction string based on the order of appearance.
+
+        Args:
+            instr (str): The instruction string containing placeholders.
+
+        Returns:
+            list: A list containing the modified order of placeholders.
+        """
+        placeholders = self.placeholder_pattern.findall(instr)
+        sorted_placeholders = sorted(placeholders, key=lambda x: instr.index(x))
+        
+        # Create a new list to store the modified order of placeholders
+        modified_placeholders = []
+
+        for val in sorted_placeholders:
+            if "MULTI" in val:
+                digit_match = re.search(r'\d+', val)
+                if digit_match:
+                    digit = digit_match.group(0)
+                    modified_placeholders.append(f'<<MULTI_INTER{digit}>>')
+
+            modified_placeholders.append(val)
+
+        return (modified_placeholders)
+
+    def initialize_track_dict(self, track_dict, replacement_dict):
+        """
+        Initializes the track dictionary with proper indexes for the elements in the replacement dictionary.
+
+        Args:
+            track_dict (dict): The track dictionary to be initialized.
+            replacement_dict (dict): The replacement dictionary containing elements for indexing.
+
+        Returns:
+            dict: The initialized track dictionary.
+        """
+        for key, val in replacement_dict.items():
+            if isinstance(val, list):
+                start_index, end_index, curr_index = 0, len(val), 0
+                track_dict[key] = [start_index, end_index, curr_index]                
+
+        return track_dict
+
+    def update_replacement_dict(self, track_dict):
+        """
+        Updates the current index in the track dictionary for iterating over replacement dictionary elements.
+
+        Args:
+            track_dict (dict): The track dictionary containing index information.
+
+        Returns:
+            dict: The updated track dictionary.
+        """
+        for key, val in track_dict.items():
+            if val[2] < val[1] -1:                     #current index < end index
+                val[2] += 1
+            else:
+                val[2] = val[0]
+
+        return track_dict
+
+    def apply_operation(self, range_list, operation, digit):
+        """
+        Applies the specified operation to each element in the range list.
+
+        Args:
+            range_list (list): The list of numbers to apply the operation to.
+            operation (str): The operation to apply (e.g., '+', '-', '*', '/', '<<', '>>').
+            digit (int): The operand to use in the operation.
+
+        Returns:
+            list: The list of numbers after applying the operation and floor function to each element.
+
+        Raises:
+            ValueError: If the operation is invalid.
+        """
+        try:
+            result_list = [eval(f"x {operation} {digit}") for x in range_list]
+            # Applying the floor operation to each element in the result list
+            result_list_floor = [math.floor(num) for num in result_list]
+            return result_list_floor
+        except SyntaxError:
+            raise ValueError("Invalid operation.")
+
+    def list_index_resolver(self, list_indices):
+        values_finder = re.compile(r'\{\[(.*?)\]\}')
+        result_list = []
+        for list_index in list_indices:
+            value_inside_index = values_finder.findall(list_index)
+            resolved_val = math.floor(eval(value_inside_index[0]))
+            result_list.append(resolved_val)
+
+        return result_list
+
+
+#Translate function
+def Translate_cgf(input_cgf):
+    trans = Translator()
+    logger.info("Translating")
+    output_cgf = trans.translate(input_cgf)
+    return output_cgf
+
+
+# if __name__ == "__main__":
+#     defs_path = '/home/hammad/wrapper_cgf/Wrapper-cgf/config.defs'
+#     cgf_path  = '/home/hammad/wrapper_cgf/Wrapper-cgf/output.cgf'
+#     trans = Translator()
+#     trans.translate_using_path(defs_path, cgf_path)

--- a/riscv_isac/utils.py
+++ b/riscv_isac/utils.py
@@ -35,6 +35,18 @@ def collect_label_address(elf, label):
         main = mains[0]
     return int(main.entry['st_value'])
 
+def get_value_at_location(elf_path, location, bytes):
+    with open(elf_path, 'rb') as f:
+        elffile = ELFFile(f)
+        # Iterate through the sections to find the relevant one (or use a specific section by name)
+        for section in elffile.iter_sections():
+            if section['sh_addr'] <= location < section['sh_addr'] + section.data_size:
+                offset = location - section['sh_addr']
+                f.seek(section['sh_offset'] + offset)
+                value = f.read(bytes)  # Assuming a 32-bit value, adjust if different
+                return int.from_bytes(value, byteorder='little', signed=False)
+    return None
+
 def dump_yaml(foo, outfile):
     yaml.dump(foo, outfile)
 


### PR DESCRIPTION
# mnemonic flag support:
The `mnemonic` can be used to write a coverpoint that should target a instruction of interest only. For instance, **lr** or **sc**. Coverpoint can be written in the following pattern:
```objective-c
csr_comb:
    mnemonic == 'lr' : 0
```