### PR TITLE
Add zilsd and zcmlsd instruction support

### DIFF
--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -1,7 +1,7 @@
 import struct
 
 instrs_sig_mutable = ['auipc','jal','jalr']
-instrs_sig_update = ['sh','sb','sw','sd','c.fsw','c.sw','c.sd','c.swsp','c.sdsp','fsw','fsd',\
+instrs_sig_update = ['sh','sb','sw','sd','sdz','c.fsw','c.sw','c.sd','c.sdz','c.swsp','c.sdsp','c.sdspz','fsw','fsd',\
         'c.fsw','c.fsd','c.fswsp','c.fsdsp']
 instrs_no_reg_tracking = ['beq','bne','blt','bge','bltu','bgeu','fence','c.j','c.jal','c.jalr',\
         'c.jr','c.beqz','c.bnez', 'c.ebreak'] + instrs_sig_update
@@ -12,7 +12,7 @@ instrs_fcsr_affected = ['fmadd.s','fmsub.s','fnmsub.s','fnmadd.s','fadd.s','fsub
         'fmul.d','fdiv.d','fsqrt.d','fmin.d','fmax.d','fcvt.s.d','fcvt.d.s',\
         'feq.d','flt.d','fle.d','fcvt.w.d','fcvt.wu.d','fcvt.l.d','fcvt.lu.d',\
         'fcvt.d.l','fcvt.d.lu']
-unsgn_rs1 = ['sw','sd','sh','sb','ld','lw','lwu','lh','lhu','lb', 'lbu','flw','fld','fsw','fsd','flh','fsh',\
+unsgn_rs1 = ['sw','sd','sh','sb','ld','ldz','sdz','c.ldz','c.ldspz','c.sdz','c.sdspz','lw','lwu','lh','lhu','lb', 'lbu','flw','fld','fsw','fsd','flh','fsh',\
         'bgeu', 'bltu', 'sltiu', 'sltu','c.lw','c.lhu','c.lh','c.ld','c.lwsp','c.ldsp',\
         'c.sw','c.sd','c.swsp','c.sdsp','c.fsw','mulhu','divu','remu','divuw',\
         'remuw','aes64ds','aes64dsm','aes64es','aes64esm','aes64ks2',\
@@ -186,7 +186,7 @@ class instructionObject():
             ea_align = (rs1_val + imm_val) % 2
         if self.instr_name in ['sw','sh','sb','lw','lhu','lh','lb','lbu','lwu','flw','fsw']:
             ea_align = (rs1_val + imm_val) % 4
-        if self.instr_name in ['ld','sd','fld','fsd']:
+        if self.instr_name in ['ldz','sdz','ld','sd','fld','fsd']:
             ea_align = (rs1_val + imm_val) % 8
 
         instr_vars.update({

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -1388,7 +1388,7 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
         stats_queue.close()
 
 def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, flen, addr_pairs
-        , dump, cov_labels, sig_addrs, window_size, inxFlg, no_count=False, procs=1):
+        , dump, cov_labels, sig_addrs, window_size, inxFlg,zilsdFlg, no_count=False, procs=1):
     '''Compute the Coverage'''
 
     global arch_state
@@ -1458,6 +1458,7 @@ def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xle
     decoder_pm.register(decoderclass())
     decoder = decoder_pm.hook
     decoder.setup(inxFlag=inxFlg, arch="rv"+str(xlen))
+    decoder.setupz(zilsdFlg=zilsdFlg, arch="rv"+str(xlen))
 
     iterator = iter(parser.__iter__()[0])
 

--- a/riscv_isac/isac.py
+++ b/riscv_isac/isac.py
@@ -6,7 +6,7 @@ import riscv_isac.coverage as cov
 from elftools.elf.elffile import ELFFile
 
 def isac(output_file,elf ,trace_file, window_size, cgf, parser_name, decoder_name, parser_path, decoder_path, detailed, test_labels,
-        sig_labels, dump, cov_labels, xlen, flen, inxFlg, no_count, procs, logging=False):
+        sig_labels, dump, cov_labels, xlen, flen, inxFlg,zilsdFlg, no_count, procs, logging=False):
     test_addr = []
     sig_addr = []
     if parser_path:
@@ -37,7 +37,7 @@ def isac(output_file,elf ,trace_file, window_size, cgf, parser_name, decoder_nam
                 sig_addr.append((start_address,end_address))
     else:
         test_name = trace_file.rsplit(',',1)[0]
-    rpt = cov.compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, flen, test_addr, dump, cov_labels, sig_addr, window_size, inxFlg, no_count, procs)
+    rpt = cov.compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, flen, test_addr, dump, cov_labels, sig_addr, window_size, inxFlg,zilsdFlg, no_count, procs)
     if output_file is not None and logging:
         logger.info('Coverage Report:')
         #logger.info('\n\n' + rpt)

--- a/riscv_isac/main.py
+++ b/riscv_isac/main.py
@@ -135,11 +135,15 @@ def cli(verbose):
         default = False, 
         help="Enable inxFlg if the extension is Z*inx"
 )
-
+@click.option('--zilsdFlg', 'zilsdFlg',
+        type=bool, 
+        default = False, 
+        help="Enable zilsdFlg if the extension is Zilsd"
+)
 def coverage(elf,trace_file, window_size, cgf_file, detailed,parser_name, decoder_name, parser_path, decoder_path,output_file, test_label,
-        sig_label, dump,cov_label, xlen, flen, no_count, procs, log_redundant, inxFlg):
+        sig_label, dump,cov_label, xlen, flen, no_count, procs, log_redundant, inxFlg,zilsdFlg):
     isac(output_file,elf,trace_file, window_size, expand_cgf(cgf_file,int(xlen),int(flen),log_redundant), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
-            sig_label, dump, cov_label, int(xlen), int(flen), inxFlg, no_count, procs)
+            sig_label, dump, cov_label, int(xlen), int(flen), inxFlg, zilsdFlg, no_count, procs)
 
 @cli.command(help = "Merge given coverage files.")
 @click.argument(

--- a/riscv_isac/plugins/internaldecoder.py
+++ b/riscv_isac/plugins/internaldecoder.py
@@ -408,7 +408,10 @@ class disassembler():
     @plugins.decoderHookImpl
     def setup(self, arch):
         self.arch = arch
-
+    @plugins.decoderHookImpl
+    def setupz(self, zilsdFlg,arch: str):
+        self.arch = arch
+        self.zilsdFlg = zilsdFlg
     FIRST2_MASK = 0x00000003
     OPCODE_MASK = 0x0000007f
     FUNCT3_MASK = 0x00007000
@@ -529,6 +532,8 @@ class disassembler():
             instrObj.instr_name = 'lwu'
         if funct3 == 0b011:
             instrObj.instr_name = 'ld'
+        if funct3 == 0b011 and self.arch == 'rv32' and self.zilsdFlg is True :
+            instrObj.instr_name = 'ldz'
 
         return instrObj
 
@@ -553,6 +558,8 @@ class disassembler():
             instrObj.instr_name = 'sw'
         if funct3 == 0b011:
             instrObj.instr_name = 'sd'
+        if funct3 == 0b011 and self.arch == 'rv32' and self.zilsdFlg is True :
+            instrObj.instr_name = 'sdz'
 
         return instrObj
 
@@ -2049,7 +2056,12 @@ class disassembler():
             instrObj.imm = uimm_6_5_3_2
 
         elif funct3 == 0b011:
-            if self.arch == 'rv32':
+            if self.arch == 'rv32' and self.zilsdFlg is True :
+                instrObj.instr_name = 'c.ldz'
+                instrObj.rd = (8 + rdprime, 'x')
+                instrObj.rs1 = (8 + rs1prime, 'x')
+                instrObj.imm = uimm_7_6_5_3
+            elif self.arch == 'rv32':
                 instrObj.instr_name = 'c.flw'
                 instrObj.rd = (8 + rdprime, 'f')
                 instrObj.rs1 = (8 + rs1prime, 'x')
@@ -2073,7 +2085,12 @@ class disassembler():
             instrObj.imm = uimm_6_5_3_2
 
         elif funct3 == 0b111:
-            if self.arch == 'rv32':
+            if self.arch == 'rv32' and self.zilsdFlg is True :
+                instrObj.instr_name = 'c.sdz'
+                instrObj.rs1 = (8 + rs1prime, 'x')
+                instrObj.rs2 = (8 + rs2prime, 'x')
+                instrObj.imm = uimm_7_6_5_3
+            elif self.arch == 'rv32':
                 instrObj.instr_name = 'c.fsw'
                 instrObj.rs1 = (8 + rs1prime, 'x')
                 instrObj.rs2 = (8 + rs2prime, 'f')
@@ -2275,6 +2292,11 @@ class disassembler():
             instrObj.rs1 = (2, 'x')
             instrObj.rd = (rd, 'x')
             instrObj.imm = imm_lwsp
+        elif funct3 == 3 and self.arch == 'rv32' and self.zilsdFlg is True:
+            instrObj.instr_name = 'c.ldspz'
+            instrObj.rd = (rd, 'x')
+            instrObj.rs1 = (2, 'x')
+            instrObj.imm = imm_ldsp
         elif funct3 == 3 and self.arch == 'rv32':
             instrObj.instr_name = 'c.flwsp'
             instrObj.rd = (rd, 'f')
@@ -2282,7 +2304,7 @@ class disassembler():
             instrObj.imm = imm_lwsp
         elif funct3 == 3 and self.arch == 'rv64':
             instrObj.instr_name = 'c.ldsp'
-            instrObj.rd = (rd, 'f')
+            instrObj.rd = (rd, 'x')
             instrObj.rs1 = (2, 'x')
             instrObj.imm = imm_ldsp
         elif funct3 == 4 and rs1 != 0 and imm_5 == 0 and rs2 == 0:
@@ -2314,7 +2336,12 @@ class disassembler():
             instrObj.rs2 = (rs2, 'x')
             instrObj.imm = imm_swsp
             instrObj.rs1 = (2 , 'x')
-        elif funct3 == 7 and self.arch == 'rv32':
+        elif funct3 == 7 and self.arch == 'rv32' and self.zilsdFlg is True:
+            instrObj.instr_name = 'c.sdspz'
+            instrObj.rs2 = (rs2, 'x')
+            instrObj.rs1 = (2, 'x')
+            instrObj.imm = imm_fsdsp
+        elif funct3 == 7 and self.arch == 'rv32' :
             instrObj.instr_name = 'c.fswsp'
             instrObj.rs2 = (rs2, 'f')
             instrObj.rs1 = (2, 'x')


### PR DESCRIPTION


## Description

Adding Support for Zilsd and Zcmlsd Extensions presented here:

### Related Issues

Toolchain updates: 
- https://github.com/nxp-auto-tools/binutils_zilsd/tree/zilsd
- https://github.com/nxp-auto-tools/gcc_zilsd/tree/zilsd

The related PRs 
- riscv-config support for the extension merged in dev [PR](https://github.com/riscv-software-src/riscv-config/pull/177)
- riscv-isa-sim support for the extension available in master : [commit id](https://github.com/riscv-software-src/riscv-isa-sim/commit/70d26d64e6ba2da329357a88dc313277fff6c22c)
- [SAIL PR](https://github.com/riscv/sail-riscv/pull/490)
- [riscv-ctg PR](https://github.com/riscv-software-src/riscv-ctg/pull/117)
