### PR TITLE
inxFlg not defined error resolved for the coverage command

### DIFF
--- a/riscv_isac/isac.py
+++ b/riscv_isac/isac.py
@@ -58,7 +58,7 @@ def preprocessing(cgf, header_file, cgf_macros):
         return cgf
 
 def isac(output_file,elf ,trace_file, window_size, cgf, parser_name, decoder_name, parser_path, decoder_path, detailed, test_labels,
-        sig_labels, dump, cov_labels, xlen, flen, no_count, procs, *inxFlg, logging=False):
+        sig_labels, dump, cov_labels, xlen, flen, no_count, procs, inxFlg, logging=False):
     test_addr = []
     sig_addr = []
     if parser_path:

--- a/riscv_isac/main.py
+++ b/riscv_isac/main.py
@@ -151,9 +151,9 @@ def cli(verbose):
 )
 
 def coverage(elf,trace_file, header_file, window_size, cgf_file, detailed,parser_name, decoder_name, parser_path, decoder_path,output_file, test_label,
-        sig_label, dump,cov_label, cgf_macro, xlen, flen, no_count, procs, log_redundant):  
+        sig_label, dump,cov_label, cgf_macro, xlen, flen, no_count, procs, log_redundant, inxFlg):  
     isac(output_file,elf,trace_file, window_size, preprocessing(Translate_cgf(expand_cgf(cgf_file,int(xlen),int(flen),log_redundant)), header_file, cgf_macro), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
-            sig_label, dump, cov_label, int(xlen), int(flen), no_count, procs)
+            sig_label, dump, cov_label, int(xlen), int(flen), no_count, procs, inxFlg)
 
 @cli.command(help = "Merge given coverage files.")
 @click.argument(


### PR DESCRIPTION
This PR resolves the inxFlg error issue while running the coverage command:
```
Traceback (most recent call last):
  File "/usr/local/bin/riscv_isac", line 33, in <module>
    sys.exit(load_entry_point('riscv-isac', 'console_scripts', 'riscv_isac')())
  File "/home/hammad/.local/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/hammad/.local/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/hammad/.local/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/hammad/.local/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/hammad/.local/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
TypeError: coverage() got an unexpected keyword argument 'inxFlg'
make: *** [/home/hammad/random_tests_env/riscof_work/Makefile.Reference-sail_c_simulator:5: TARGET0] Error 1
    INFO | Merging Coverage reports
Traceback (most recent call last):
  File "/usr/local/bin/riscof", line 33, in <module>
    sys.exit(load_entry_point('riscof', 'console_scripts', 'riscof')())
  File "/home/hammad/.local/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/hammad/.local/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/hammad/.local/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/hammad/.local/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/hammad/.local/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/hammad/.local/lib/python3.10/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/hammad/RISCOF_COMPLETE/riscof/riscof/cli.py", line 406, in coverage
    report, for_html, test_stats, coverpoints = framework.run_coverage(base, isa_file, platform_file,
  File "/home/hammad/RISCOF_COMPLETE/riscof/riscof/framework/main.py", line 129, in run_coverage
    'test_size': [str(entry) for entry in find_elf_size(elf)],
  File "/home/hammad/RISCOF_COMPLETE/riscof/riscof/framework/main.py", line 61, in find_elf_size
    with open(elf, 'rb') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/hammad/random_tests_env/riscof_work/src/divu-01.S/ref.elf'
```

After these changes, the coverage command runs successfully:
```
   INFO | ****** RISCOF: RISC-V Architectural Test Framework right this 1.25.3 *******
    INFO | using riscv_isac version : 0.18.0
    INFO | using riscv_config version : 3.9.2
    INFO | Reading configuration from: /home/hammad/tests-arch-final/riscv-arch-test/config.ini
    INFO | Preparing Models
    INFO | Input-ISA file
    INFO | Loading input file: /home/hammad/tests-arch-final/riscv-arch-test/spike/spike_isa.yaml
    INFO | Load Schema /usr/local/lib/python3.10/dist-packages/riscv_config/schemas/schema_isa.yaml
    INFO | Processing Hart: hart0
    INFO | Initiating Validation
    INFO | No errors for Hart: 0 :)
    INFO |  Updating fields node for each CSR
    INFO | Dumping out Normalized Checked YAML: /home/hammad/random_tests_env/riscof_work/spike_isa_checked.yaml
    INFO | Input-Platform file
    INFO | Loading input file: /home/hammad/tests-arch-final/riscv-arch-test/spike/spike_platform.yaml
    INFO | Load Schema /usr/local/lib/python3.10/dist-packages/riscv_config/schemas/schema_platform.yaml
    INFO | Initiating Validation
    INFO | No Syntax errors in Input Platform Yaml. :)
    INFO | Dumping out Normalized Checked YAML: /home/hammad/random_tests_env/riscof_work/spike_platform_checked.yaml
    INFO | Generating database for suite: /home/hammad/riscv-arch-test/riscv-test-suite/rv32i_m/M
    INFO | Database File Generated: /home/hammad/random_tests_env/riscof_work/database.yaml
    INFO | Env path set to/home/hammad/riscv-arch-test/riscv-test-suite/env
    INFO | Will collect Coverage using RISCV-ISAC
    INFO | CGF file(s) being used : ('/home/hammad/riscv-ctg/sample_cgfs/dataset.cgf', '/home/hammad/riscv-arch-test/coverage/rvi_m.cgf')
    INFO | Selecting Tests.
    INFO | Running Tests on Reference.
    INFO | Merging Coverage reports
['/home/hammad/random_tests_env/riscof_work/src/div-01.S/ref.cgf', '/home/hammad/random_tests_env/riscof_work/src/divu-01.S/ref.cgf', '/home/hammad/random_tests_env/riscof_work/src/mul-01.S/ref.cgf', '/home/hammad/random_tests_env/riscof_work/src/mulh-01.S/ref.cgf', '/home/hammad/random_tests_env/riscof_work/src/mulhsu-01.S/ref.cgf', '/home/hammad/random_tests_env/riscof_work/src/mulhu-01.S/ref.cgf', '/home/hammad/random_tests_env/riscof_work/src/rem-01.S/ref.cgf', '/home/hammad/random_tests_env/riscof_work/src/remu-01.S/ref.cgf']
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
 WARNING | Deprecated node used: 'opcode'. Use 'mnemonics' instead
    INFO | Translating
    INFO | Preprocessing
    INFO | Test report generated at /home/hammad/random_tests_env/riscof_work/coverage.html.
    INFO | Opening test report in web-bro
```